### PR TITLE
feat: add CSV/JSON export and webhook notifications (v0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ tracks artifacts between steps, and allows replaying and inspecting runs.
 - **Budget & cost tracking** &mdash; per-node cost records, budget enforcement (stop/warn), CLI cost inspection
 - **Framework adapters** &mdash; plug in LangChain, CrewAI, or AutoGen agents with a single URI
 - **Plugin system** &mdash; extend Binex with custom adapter plugins via entry points
+- **Export & webhooks** &mdash; export runs to CSV/JSON, webhook notifications on run events
 - **CLI-first DX** &mdash; everything accessible from the terminal
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -333,6 +334,7 @@ nodes:
 | `binex cost show <run-id>` | Cost breakdown per node (`--json`) |
 | `binex cost history <run-id>` | Chronological cost events (`--json`) |
 | `binex explore` | Interactive browser for runs and artifacts |
+| `binex export <run-id>` | Export run data to CSV (`--format json`, `--last N`, `--include-artifacts`) |
 | `binex plugins list` | Show built-in adapters and installed plugins (`--json`) |
 | `binex plugins check <workflow>` | Validate all agent URIs are resolvable |
 | `binex hello` | Zero-config demo |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,8 +20,8 @@
 
 - [ ] OpenTelemetry integration (traces, metrics, spans)
 - [ ] Workflow versioning and migration
-- [ ] Export runs to Parquet / CSV for analysis
-- [ ] Webhook notifications on run completion / failure
+- [x] Export runs to CSV / JSON for analysis
+- [x] Webhook notifications on run completion / failure / budget exceeded
 
 ## v1.0 — Production Ready
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "binex"
-version = "0.3.0"
+version = "0.4.0"
 description = "Debuggable runtime for AI agent pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/binex/__init__.py
+++ b/src/binex/__init__.py
@@ -1,5 +1,5 @@
 """Binex — debuggable runtime for A2A agents."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = ["__version__"]

--- a/src/binex/cli/__init__.py
+++ b/src/binex/cli/__init__.py
@@ -104,7 +104,7 @@ COMMAND_SECTIONS: list[tuple[str, list[str]]] = [
     ("Core commands", ["run", "cancel", "replay"]),
     ("Inspect & debug", [
         "debug", "diagnose", "bisect", "trace", "diff",
-        "artifacts", "cost", "explore",
+        "artifacts", "cost", "explore", "export",
     ]),
     ("Setup & scaffold", ["init", "start", "scaffold", "hello"]),
     ("System", ["dev", "doctor", "validate", "plugins"]),

--- a/src/binex/cli/export_cmd.py
+++ b/src/binex/cli/export_cmd.py
@@ -1,0 +1,123 @@
+"""CLI `binex export` command — export run data to CSV or JSON."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import click
+
+from binex.cli import get_stores
+
+
+def _get_stores():
+    """Create default stores. Extracted for test patching."""
+    return get_stores()
+
+
+@click.command("export")
+@click.argument("run_id", required=False, default=None)
+@click.option("--last", "last_n", type=int, default=None, help="Export the N most recent runs.")
+@click.option(
+    "--format", "fmt", type=click.Choice(["csv", "json"]), default="csv",
+    help="Output format (csv or json).",
+)
+@click.option("--include-artifacts", is_flag=True, default=False, help="Include artifact content.")
+@click.option(
+    "--output", "-o", "output_dir", type=click.Path(), default=None,
+    help="Output directory.",
+)
+def export_cmd(
+    run_id: str | None,
+    last_n: int | None,
+    fmt: str,
+    include_artifacts: bool,
+    output_dir: str | None,
+) -> None:
+    """Export run data to CSV or JSON files."""
+    if run_id is None and last_n is None:
+        click.echo("Error: provide a run_id or --last N", err=True)
+        sys.exit(1)
+    asyncio.run(_export(run_id, last_n, fmt, include_artifacts, output_dir))
+
+
+async def _export(
+    run_id: str | None,
+    last_n: int | None,
+    fmt: str,
+    include_artifacts: bool,
+    output_dir: str | None,
+) -> None:
+    from binex.export import write_costs_csv, write_json, write_records_csv, write_runs_csv
+
+    execution_store, artifact_store = _get_stores()
+    try:
+        # Determine which runs to export
+        if run_id is not None:
+            run = await execution_store.get_run(run_id)
+            if run is None:
+                click.echo(f"Error: run '{run_id}' not found.", err=True)
+                sys.exit(1)
+            runs = [run]
+        else:
+            all_runs = await execution_store.list_runs()
+            # Most recent first (by started_at descending)
+            all_runs.sort(key=lambda r: r.started_at, reverse=True)
+            runs = all_runs[:last_n]
+
+        # Determine output directory
+        if output_dir:
+            out_path = Path(output_dir)
+        elif run_id:
+            out_path = Path(f"binex-export-{run_id}")
+        else:
+            ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+            out_path = Path(f"binex-export-{ts}")
+
+        out_path.mkdir(parents=True, exist_ok=True)
+
+        # Gather all records and costs for the runs
+        all_records = []
+        all_costs = []
+        for r in runs:
+            records = await execution_store.list_records(r.run_id)
+            costs = await execution_store.list_costs(r.run_id)
+            all_records.extend(records)
+            all_costs.extend(costs)
+
+        # Gather artifacts if requested
+        artifacts = None
+        if include_artifacts:
+            artifacts = []
+            for r in runs:
+                arts = await artifact_store.list_by_run(r.run_id)
+                artifacts.extend(arts)
+
+        # Write output
+        if fmt == "csv":
+            write_runs_csv(runs, out_path / "runs.csv")
+            write_records_csv(all_records, out_path / "records.csv")
+            write_costs_csv(all_costs, out_path / "costs.csv")
+            if include_artifacts and artifacts:
+                # Artifacts always as JSON (non-tabular)
+                with open(out_path / "artifacts.json", "w") as f:
+                    json.dump(
+                        [a.model_dump() for a in artifacts],
+                        f, default=str, indent=2,
+                    )
+        else:
+            write_json(
+                runs=runs,
+                records=all_records,
+                costs=all_costs,
+                path=out_path / "export.json",
+                artifacts=artifacts,
+            )
+
+        click.echo(f"Exported {len(runs)} run(s) to {out_path}/")
+
+    finally:
+        await execution_store.close()

--- a/src/binex/cli/main.py
+++ b/src/binex/cli/main.py
@@ -17,6 +17,7 @@ from binex.cli.diagnose import diagnose_cmd
 from binex.cli.diff import diff_cmd
 from binex.cli.doctor import doctor_cmd
 from binex.cli.explore import explore_cmd
+from binex.cli.export_cmd import export_cmd
 from binex.cli.gateway_cmd import gateway
 from binex.cli.hello import hello_cmd
 from binex.cli.init_cmd import init_cmd
@@ -73,6 +74,7 @@ cli.add_command(diagnose_cmd, "diagnose")
 cli.add_command(bisect_cmd, "bisect")
 cli.add_command(gateway, "gateway")
 cli.add_command(plugins_group, "plugins")
+cli.add_command(export_cmd, "export")
 
 
 def main() -> None:

--- a/src/binex/export.py
+++ b/src/binex/export.py
@@ -1,0 +1,77 @@
+"""Export serializers — CSV and JSON writers for run data."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from binex.models.artifact import Artifact
+from binex.models.cost import CostRecord
+from binex.models.execution import ExecutionRecord, RunSummary
+
+_RUN_FIELDS = [
+    "run_id", "workflow_name", "workflow_path", "status",
+    "started_at", "completed_at", "total_nodes", "completed_nodes",
+    "failed_nodes", "skipped_nodes", "total_cost",
+]
+
+_RECORD_FIELDS = [
+    "id", "run_id", "task_id", "agent_id", "status", "latency_ms",
+    "timestamp", "trace_id", "error", "prompt", "model", "tool_calls",
+]
+
+_COST_FIELDS = [
+    "id", "run_id", "task_id", "cost", "currency", "source",
+    "prompt_tokens", "completion_tokens", "model", "timestamp",
+]
+
+
+def write_runs_csv(runs: list[RunSummary], path: Path) -> None:
+    """Write run summaries to CSV."""
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_RUN_FIELDS)
+        writer.writeheader()
+        for run in runs:
+            row = run.model_dump()
+            writer.writerow({k: row.get(k, "") for k in _RUN_FIELDS})
+
+
+def write_records_csv(records: list[ExecutionRecord], path: Path) -> None:
+    """Write execution records to CSV."""
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_RECORD_FIELDS)
+        writer.writeheader()
+        for record in records:
+            row = record.model_dump()
+            writer.writerow({k: row.get(k, "") for k in _RECORD_FIELDS})
+
+
+def write_costs_csv(costs: list[CostRecord], path: Path) -> None:
+    """Write cost records to CSV."""
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_COST_FIELDS)
+        writer.writeheader()
+        for cost in costs:
+            row = cost.model_dump()
+            writer.writerow({k: row.get(k, "") for k in _COST_FIELDS})
+
+
+def write_json(
+    *,
+    runs: list[RunSummary],
+    records: list[ExecutionRecord],
+    costs: list[CostRecord],
+    path: Path,
+    artifacts: list[Artifact] | None = None,
+) -> None:
+    """Write all data to a single JSON file."""
+    data: dict = {
+        "runs": [r.model_dump() for r in runs],
+        "records": [r.model_dump() for r in records],
+        "costs": [c.model_dump() for c in costs],
+    }
+    if artifacts is not None:
+        data["artifacts"] = [a.model_dump() for a in artifacts]
+    with open(path, "w") as f:
+        json.dump(data, f, default=str, indent=2)

--- a/src/binex/models/workflow.py
+++ b/src/binex/models/workflow.py
@@ -60,6 +60,12 @@ class DefaultsSpec(BaseModel):
     retry_policy: RetryPolicy = Field(default_factory=RetryPolicy)
 
 
+class WebhookConfig(BaseModel):
+    """Webhook notification target configuration."""
+
+    url: str
+
+
 class WorkflowSpec(BaseModel):
     """Parsed representation of a YAML/JSON workflow definition."""
 
@@ -68,6 +74,7 @@ class WorkflowSpec(BaseModel):
     nodes: dict[str, NodeSpec]
     defaults: DefaultsSpec | None = None
     budget: BudgetConfig | None = None
+    webhook: WebhookConfig | None = None
     source_path: str | None = None
 
     @model_validator(mode="after")
@@ -78,4 +85,4 @@ class WorkflowSpec(BaseModel):
         return self
 
 
-__all__ = ["BackEdge", "DefaultsSpec", "NodeSpec", "WorkflowSpec"]
+__all__ = ["BackEdge", "DefaultsSpec", "NodeSpec", "WebhookConfig", "WorkflowSpec"]

--- a/src/binex/runtime/orchestrator.py
+++ b/src/binex/runtime/orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -28,6 +29,7 @@ from binex.runtime.budget import (
 from binex.runtime.dispatcher import Dispatcher, _backoff_delay
 from binex.stores.artifact_store import ArtifactStore
 from binex.stores.execution_store import ExecutionStore
+from binex.webhook import WebhookSender
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +126,16 @@ class Orchestrator:
         )
 
         await self.execution_store.update_run(summary)
+
+        # Fire webhook if configured
+        webhook_url = (
+            spec.webhook.url if spec.webhook
+            else os.environ.get("BINEX_WEBHOOK_URL")
+        )
+        sender = WebhookSender.from_config(url=webhook_url)
+        if sender is not None:
+            await self._fire_webhook(sender, spec, summary)
+
         return summary
 
     def _schedule_ready_nodes(
@@ -171,6 +183,46 @@ class Orchestrator:
         if scheduler.is_complete():
             return "completed"
         return "failed"
+
+    @staticmethod
+    async def _fire_webhook(
+        sender: WebhookSender,
+        spec: WorkflowSpec,
+        summary: RunSummary,
+    ) -> None:
+        """Send webhook notification for run lifecycle event."""
+        event_map = {
+            "completed": "run.completed",
+            "failed": "run.failed",
+            "over_budget": "run.budget_exceeded",
+        }
+        event = event_map.get(summary.status)
+        if event is None:
+            return
+
+        data: dict[str, Any] = {
+            "status": summary.status,
+            "total_cost": summary.total_cost,
+            "total_nodes": summary.total_nodes,
+            "completed_nodes": summary.completed_nodes,
+            "failed_nodes": summary.failed_nodes,
+            "skipped_nodes": summary.skipped_nodes,
+        }
+        if summary.status == "over_budget" and spec.budget:
+            data["max_cost"] = spec.budget.max_cost
+
+        payload = {
+            "event": event,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "run_id": summary.run_id,
+            "workflow_name": spec.name,
+            "data": data,
+        }
+
+        try:
+            await sender.send(payload)
+        except Exception as exc:
+            logger.warning("Webhook delivery error: %s", exc)
 
     async def _budget_pre_check(
         self,

--- a/src/binex/webhook.py
+++ b/src/binex/webhook.py
@@ -1,0 +1,53 @@
+"""WebhookSender — async HTTP POST with retry and exponential backoff."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_MAX_RETRIES = 3
+_BACKOFF_DELAYS = [1, 2, 4]  # seconds
+_TIMEOUT = 10  # seconds
+
+
+class WebhookSender:
+    """Sends webhook payloads with retry logic."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+    @classmethod
+    def from_config(cls, *, url: str | None) -> WebhookSender | None:
+        """Factory: return a sender if url is provided, else None."""
+        if not url:
+            return None
+        return cls(url=url)
+
+    async def send(self, payload: dict[str, Any]) -> bool:
+        """POST payload to webhook URL with retries. Returns True on success."""
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            for attempt in range(_MAX_RETRIES):
+                try:
+                    response = await client.post(self.url, json=payload)
+                    response.raise_for_status()
+                    return True
+                except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException) as exc:
+                    if attempt < _MAX_RETRIES - 1:
+                        delay = _BACKOFF_DELAYS[attempt]
+                        logger.warning(
+                            "Webhook delivery failed (attempt %d/%d): %s. "
+                            "Retrying in %ds...",
+                            attempt + 1, _MAX_RETRIES, exc, delay,
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        logger.warning(
+                            "Webhook delivery failed after %d attempts: %s",
+                            _MAX_RETRIES, exc,
+                        )
+        return False

--- a/tests/e2e/test_e2e_export.py
+++ b/tests/e2e/test_e2e_export.py
@@ -1,0 +1,128 @@
+"""E2E tests for binex export command — real subprocess, real SQLite, real filesystem."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.conftest import extract_run_id, run_binex, write_workflow
+
+
+SIMPLE_WORKFLOW = """\
+name: export-test
+nodes:
+  greet:
+    agent: "local://echo"
+    inputs:
+      message: "Hello from export test"
+    outputs: [greeting]
+"""
+
+
+def _extract_run_id_from_output(output: str) -> str:
+    """Extract run_id from binex output, handles both plain and Rich formats."""
+    import re
+    # Match "Run Id: run_xxxx" or "Run ID: run_xxxx" (Rich panel or plain text)
+    m = re.search(r"Run\s+Id:\s+(run_\w+)", output, re.IGNORECASE)
+    if m:
+        return m.group(1)
+    return extract_run_id(output)
+
+
+@pytest.fixture
+def run_with_data(binex_env, tmp_path):
+    """Run a simple workflow and return (env, run_id, tmp_path)."""
+    env, store_path, _ = binex_env
+    wf_path = write_workflow(tmp_path, "export-test", SIMPLE_WORKFLOW)
+    result = run_binex("run", str(wf_path), env=env, cwd=tmp_path)
+    run_id = _extract_run_id_from_output(result.stdout + result.stderr)
+    return env, run_id, tmp_path
+
+
+class TestExportCsvE2E:
+    def test_single_run_csv_export(self, run_with_data):
+        """T050: single run CSV export."""
+        env, run_id, tmp_path = run_with_data
+        out_dir = tmp_path / "csv-export"
+
+        result = run_binex(
+            "export", run_id, "--output", str(out_dir), env=env, cwd=tmp_path,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert (out_dir / "runs.csv").exists()
+        assert (out_dir / "records.csv").exists()
+        assert (out_dir / "costs.csv").exists()
+
+        # Verify CSV content
+        with open(out_dir / "runs.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["run_id"] == run_id
+
+
+class TestExportJsonE2E:
+    def test_single_run_json_export(self, run_with_data):
+        """T051: single run JSON export."""
+        env, run_id, tmp_path = run_with_data
+        out_dir = tmp_path / "json-export"
+
+        result = run_binex(
+            "export", run_id, "--format", "json",
+            "--output", str(out_dir), env=env, cwd=tmp_path,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        export_file = out_dir / "export.json"
+        assert export_file.exists()
+
+        data = json.loads(export_file.read_text())
+        assert "runs" in data
+        assert "records" in data
+        assert "costs" in data
+        assert len(data["runs"]) == 1
+        assert data["runs"][0]["run_id"] == run_id
+
+
+class TestExportMultiRunE2E:
+    def test_last_n_export(self, binex_env, tmp_path):
+        """T052: --last N multi-run export."""
+        env, store_path, _ = binex_env
+        wf_path = write_workflow(tmp_path, "multi-test", SIMPLE_WORKFLOW)
+
+        # Run workflow twice
+        run_binex("run", str(wf_path), env=env, cwd=tmp_path)
+        run_binex("run", str(wf_path), env=env, cwd=tmp_path)
+
+        out_dir = tmp_path / "multi-export"
+        result = run_binex(
+            "export", "--last", "2", "--output", str(out_dir),
+            env=env, cwd=tmp_path,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        with open(out_dir / "runs.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 2
+
+
+class TestExportErrorE2E:
+    def test_nonexistent_run_error(self, binex_env, tmp_path):
+        """T053: nonexistent run error."""
+        env, _, _ = binex_env
+        result = run_binex("export", "run_nonexistent", env=env, cwd=tmp_path)
+        assert result.returncode != 0
+
+
+class TestExportInHelp:
+    def test_export_appears_in_help(self, binex_env):
+        """T054: export appears in binex --help."""
+        env, _, _ = binex_env
+        result = run_binex("--help", env=env)
+        assert result.returncode == 0
+        assert "export" in result.stdout

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,0 +1,230 @@
+"""Unit tests for export serializers (CSV/JSON writers)."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from binex.models.artifact import Artifact, Lineage
+from binex.models.cost import CostRecord
+from binex.models.execution import ExecutionRecord, RunSummary
+
+
+def _make_run(run_id: str = "run_abc") -> RunSummary:
+    return RunSummary(
+        run_id=run_id,
+        workflow_name="test-wf",
+        workflow_path="test.yaml",
+        status="completed",
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 0, 5, tzinfo=UTC),
+        total_nodes=2,
+        completed_nodes=2,
+        total_cost=0.05,
+    )
+
+
+def _make_record(run_id: str = "run_abc") -> ExecutionRecord:
+    return ExecutionRecord(
+        id="rec_1",
+        run_id=run_id,
+        task_id="node_a",
+        agent_id="llm://gpt-4o",
+        status="completed",
+        latency_ms=1200,
+        timestamp=datetime(2026, 1, 1, 0, 1, tzinfo=UTC),
+        trace_id="trace_1",
+    )
+
+
+def _make_cost(run_id: str = "run_abc") -> CostRecord:
+    return CostRecord(
+        id="cost_1",
+        run_id=run_id,
+        task_id="node_a",
+        cost=0.05,
+        source="llm_tokens",
+        prompt_tokens=100,
+        completion_tokens=50,
+        model="gpt-4o",
+        timestamp=datetime(2026, 1, 1, 0, 1, tzinfo=UTC),
+    )
+
+
+def _make_artifact(run_id: str = "run_abc") -> Artifact:
+    return Artifact(
+        id="art_1",
+        run_id=run_id,
+        type="text",
+        content="Hello world",
+        lineage=Lineage(produced_by="node_a"),
+        created_at=datetime(2026, 1, 1, 0, 2, tzinfo=UTC),
+    )
+
+
+# ---- CSV writer tests ----
+
+
+class TestWriteRunsCsv:
+    def test_writes_csv_with_headers_and_data(self, tmp_path: Path):
+        from binex.export import write_runs_csv
+
+        path = tmp_path / "runs.csv"
+        write_runs_csv([_make_run()], path)
+
+        assert path.exists()
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["run_id"] == "run_abc"
+        assert rows[0]["workflow_name"] == "test-wf"
+        assert rows[0]["status"] == "completed"
+
+    def test_empty_list_writes_headers_only(self, tmp_path: Path):
+        from binex.export import write_runs_csv
+
+        path = tmp_path / "runs.csv"
+        write_runs_csv([], path)
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 0
+        # Headers should still exist
+        with open(path) as f:
+            header = f.readline().strip()
+        assert "run_id" in header
+
+    def test_multiple_runs(self, tmp_path: Path):
+        from binex.export import write_runs_csv
+
+        path = tmp_path / "runs.csv"
+        runs = [_make_run("run_1"), _make_run("run_2")]
+        write_runs_csv(runs, path)
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 2
+
+
+class TestWriteRecordsCsv:
+    def test_writes_records_csv(self, tmp_path: Path):
+        from binex.export import write_records_csv
+
+        path = tmp_path / "records.csv"
+        write_records_csv([_make_record()], path)
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["task_id"] == "node_a"
+        assert rows[0]["agent_id"] == "llm://gpt-4o"
+
+    def test_empty_records(self, tmp_path: Path):
+        from binex.export import write_records_csv
+
+        path = tmp_path / "records.csv"
+        write_records_csv([], path)
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 0
+
+
+class TestWriteCostsCsv:
+    def test_writes_costs_csv(self, tmp_path: Path):
+        from binex.export import write_costs_csv
+
+        path = tmp_path / "costs.csv"
+        write_costs_csv([_make_cost()], path)
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["task_id"] == "node_a"
+        assert float(rows[0]["cost"]) == 0.05
+
+    def test_empty_costs(self, tmp_path: Path):
+        from binex.export import write_costs_csv
+
+        path = tmp_path / "costs.csv"
+        write_costs_csv([], path)
+
+        with open(path) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 0
+
+
+# ---- JSON writer tests ----
+
+
+class TestWriteJson:
+    def test_writes_json_with_all_sections(self, tmp_path: Path):
+        from binex.export import write_json
+
+        path = tmp_path / "export.json"
+        write_json(
+            runs=[_make_run()],
+            records=[_make_record()],
+            costs=[_make_cost()],
+            path=path,
+        )
+
+        data = json.loads(path.read_text())
+        assert "runs" in data
+        assert "records" in data
+        assert "costs" in data
+        assert len(data["runs"]) == 1
+        assert data["runs"][0]["run_id"] == "run_abc"
+
+    def test_json_with_artifacts(self, tmp_path: Path):
+        from binex.export import write_json
+
+        path = tmp_path / "export.json"
+        write_json(
+            runs=[_make_run()],
+            records=[_make_record()],
+            costs=[_make_cost()],
+            path=path,
+            artifacts=[_make_artifact()],
+        )
+
+        data = json.loads(path.read_text())
+        assert "artifacts" in data
+        assert len(data["artifacts"]) == 1
+        assert data["artifacts"][0]["content"] == "Hello world"
+
+    def test_json_without_artifacts(self, tmp_path: Path):
+        from binex.export import write_json
+
+        path = tmp_path / "export.json"
+        write_json(
+            runs=[_make_run()],
+            records=[],
+            costs=[],
+            path=path,
+        )
+
+        data = json.loads(path.read_text())
+        assert "artifacts" not in data
+
+    def test_empty_data(self, tmp_path: Path):
+        from binex.export import write_json
+
+        path = tmp_path / "export.json"
+        write_json(runs=[], records=[], costs=[], path=path)
+
+        data = json.loads(path.read_text())
+        assert data["runs"] == []
+        assert data["records"] == []
+        assert data["costs"] == []

--- a/tests/unit/test_export_cli.py
+++ b/tests/unit/test_export_cli.py
@@ -1,0 +1,256 @@
+"""Unit tests for binex export CLI command."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from binex.cli.main import cli
+from binex.models.artifact import Artifact, Lineage
+from binex.models.cost import CostRecord
+from binex.models.execution import ExecutionRecord, RunSummary
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+
+def _make_run(run_id: str = "run_abc") -> RunSummary:
+    return RunSummary(
+        run_id=run_id,
+        workflow_name="test-wf",
+        workflow_path="test.yaml",
+        status="completed",
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 0, 5, tzinfo=UTC),
+        total_nodes=2,
+        completed_nodes=2,
+        total_cost=0.05,
+    )
+
+
+def _make_record(run_id: str = "run_abc") -> ExecutionRecord:
+    return ExecutionRecord(
+        id="rec_1",
+        run_id=run_id,
+        task_id="node_a",
+        agent_id="llm://gpt-4o",
+        status="completed",
+        latency_ms=1200,
+        timestamp=datetime(2026, 1, 1, 0, 1, tzinfo=UTC),
+        trace_id="trace_1",
+    )
+
+
+def _make_cost(run_id: str = "run_abc") -> CostRecord:
+    return CostRecord(
+        id="cost_1",
+        run_id=run_id,
+        task_id="node_a",
+        cost=0.05,
+        source="llm_tokens",
+        prompt_tokens=100,
+        completion_tokens=50,
+        model="gpt-4o",
+        timestamp=datetime(2026, 1, 1, 0, 1, tzinfo=UTC),
+    )
+
+
+def _make_artifact(run_id: str = "run_abc") -> Artifact:
+    return Artifact(
+        id="art_1",
+        run_id=run_id,
+        type="text",
+        content="Hello world",
+        lineage=Lineage(produced_by="node_a"),
+        created_at=datetime(2026, 1, 1, 0, 2, tzinfo=UTC),
+    )
+
+
+async def _populate_store(exec_store, art_store, run_id="run_abc"):
+    """Populate stores with test data."""
+    await exec_store.create_run(_make_run(run_id))
+    await exec_store.record(_make_record(run_id))
+    await exec_store.record_cost(_make_cost(run_id))
+    art = _make_artifact(run_id)
+    await art_store.store(art)
+
+
+def _make_stores():
+    return InMemoryExecutionStore(), InMemoryArtifactStore()
+
+
+# ---- US1: Single run CSV export ----
+
+
+class TestExportSingleRunCsv:
+    def test_creates_output_dir_with_3_csv_files(self, tmp_path: Path):
+        """T009: single run CSV export creates output dir with 3 CSV files."""
+        exec_store, art_store = _make_stores()
+        import asyncio
+        asyncio.run(_populate_store(exec_store, art_store))
+
+        with patch("binex.cli.export_cmd._get_stores", return_value=(exec_store, art_store)):
+            runner = CliRunner()
+            out_dir = tmp_path / "out"
+            result = runner.invoke(cli, ["export", "run_abc", "--output", str(out_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert (out_dir / "runs.csv").exists()
+        assert (out_dir / "records.csv").exists()
+        assert (out_dir / "costs.csv").exists()
+
+        # Verify CSV content
+        with open(out_dir / "runs.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["run_id"] == "run_abc"
+
+    def test_nonexistent_run_returns_error(self):
+        """T010: nonexistent run returns error exit code."""
+        exec_store, art_store = _make_stores()
+
+        with patch("binex.cli.export_cmd._get_stores", return_value=(exec_store, art_store)):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["export", "run_nonexistent"])
+
+        assert result.exit_code != 0
+
+    def test_empty_costs_produce_csv_with_headers_only(self, tmp_path: Path):
+        """T011: empty cost records produce CSV with headers only."""
+        exec_store, art_store = _make_stores()
+        import asyncio
+        # Create run but no cost records
+        asyncio.run(exec_store.create_run(_make_run()))
+        asyncio.run(exec_store.record(_make_record()))
+
+        with patch("binex.cli.export_cmd._get_stores", return_value=(exec_store, art_store)):
+            runner = CliRunner()
+            out_dir = tmp_path / "out"
+            result = runner.invoke(cli, ["export", "run_abc", "--output", str(out_dir)])
+
+        assert result.exit_code == 0
+        with open(out_dir / "costs.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 0
+        # Headers should still exist
+        with open(out_dir / "costs.csv") as f:
+            header = f.readline().strip()
+        assert "cost" in header
+
+
+# ---- US2: JSON export ----
+
+
+class TestExportJsonFormat:
+    def test_json_export_creates_export_json(self, tmp_path: Path):
+        """T017: JSON export creates export.json with correct structure."""
+        exec_store, art_store = _make_stores()
+        import asyncio
+        asyncio.run(_populate_store(exec_store, art_store))
+
+        with patch("binex.cli.export_cmd._get_stores", return_value=(exec_store, art_store)):
+            runner = CliRunner()
+            out_dir = tmp_path / "out"
+            result = runner.invoke(
+                cli, ["export", "run_abc", "--format", "json", "--output", str(out_dir)],
+            )
+
+        assert result.exit_code == 0, result.output
+        export_file = out_dir / "export.json"
+        assert export_file.exists()
+        data = json.loads(export_file.read_text())
+        assert "runs" in data
+        assert "records" in data
+        assert "costs" in data
+        assert len(data["runs"]) == 1
+
+
+# ---- US3: Multi-run export ----
+
+
+class TestExportMultiRun:
+    def test_last_n_exports_multiple_runs(self, tmp_path: Path):
+        """T021: --last N exports multiple runs to CSV."""
+        exec_store, art_store = _make_stores()
+        import asyncio
+        asyncio.run(_populate_store(exec_store, art_store, "run_1"))
+        asyncio.run(_populate_store(exec_store, art_store, "run_2"))
+        asyncio.run(_populate_store(exec_store, art_store, "run_3"))
+
+        with patch("binex.cli.export_cmd._get_stores", return_value=(exec_store, art_store)):
+            runner = CliRunner()
+            out_dir = tmp_path / "out"
+            result = runner.invoke(cli, ["export", "--last", "2", "--output", str(out_dir)])
+
+        assert result.exit_code == 0, result.output
+        with open(out_dir / "runs.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 2
+
+    def test_last_n_greater_than_total_exports_all(self, tmp_path: Path):
+        """T022: --last N with N > total runs exports all without error."""
+        exec_store, art_store = _make_stores()
+        import asyncio
+        asyncio.run(_populate_store(exec_store, art_store, "run_1"))
+
+        with patch("binex.cli.export_cmd._get_stores", return_value=(exec_store, art_store)):
+            runner = CliRunner()
+            out_dir = tmp_path / "out"
+            result = runner.invoke(cli, ["export", "--last", "100", "--output", str(out_dir)])
+
+        assert result.exit_code == 0
+        with open(out_dir / "runs.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 1
+
+
+# ---- US4: Export with artifacts ----
+
+
+class TestExportWithArtifacts:
+    def test_include_artifacts_adds_artifacts_json_to_csv(self, tmp_path: Path):
+        """T026: --include-artifacts adds artifacts.json to CSV export."""
+        exec_store, art_store = _make_stores()
+        import asyncio
+        asyncio.run(_populate_store(exec_store, art_store))
+
+        with patch("binex.cli.export_cmd._get_stores", return_value=(exec_store, art_store)):
+            runner = CliRunner()
+            out_dir = tmp_path / "out"
+            result = runner.invoke(
+                cli, ["export", "run_abc", "--include-artifacts", "--output", str(out_dir)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert (out_dir / "artifacts.json").exists()
+        data = json.loads((out_dir / "artifacts.json").read_text())
+        assert len(data) == 1
+        assert data[0]["content"] == "Hello world"
+
+    def test_include_artifacts_with_json_format(self, tmp_path: Path):
+        """T027: --include-artifacts with --format json includes artifacts in export.json."""
+        exec_store, art_store = _make_stores()
+        import asyncio
+        asyncio.run(_populate_store(exec_store, art_store))
+
+        with patch("binex.cli.export_cmd._get_stores", return_value=(exec_store, art_store)):
+            runner = CliRunner()
+            out_dir = tmp_path / "out"
+            result = runner.invoke(
+                cli,
+                ["export", "run_abc", "--format", "json",
+                 "--include-artifacts", "--output", str(out_dir)],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads((out_dir / "export.json").read_text())
+        assert "artifacts" in data
+        assert len(data["artifacts"]) == 1

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -4,4 +4,4 @@ import binex
 
 
 def test_version():
-    assert binex.__version__ == "0.3.0"
+    assert binex.__version__ == "0.4.0"

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -1,0 +1,157 @@
+"""Unit tests for WebhookSender with retry logic."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from binex.webhook import WebhookSender
+
+
+@pytest.fixture
+def sender():
+    return WebhookSender(url="https://example.com/hook")
+
+
+class TestWebhookSenderInit:
+    def test_creates_with_url(self):
+        s = WebhookSender(url="https://example.com/hook")
+        assert s.url == "https://example.com/hook"
+
+    def test_from_config_with_url(self):
+        s = WebhookSender.from_config(url="https://example.com/hook")
+        assert s is not None
+        assert s.url == "https://example.com/hook"
+
+    def test_from_config_with_none_returns_none(self):
+        s = WebhookSender.from_config(url=None)
+        assert s is None
+
+    def test_from_config_with_empty_string_returns_none(self):
+        s = WebhookSender.from_config(url="")
+        assert s is None
+
+
+class TestWebhookSenderSend:
+    @pytest.mark.asyncio
+    async def test_successful_send(self, sender: WebhookSender):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as MockClient:
+            client = AsyncMock()
+            client.post = AsyncMock(return_value=mock_response)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client
+
+            result = await sender.send({"event": "run.completed", "run_id": "r1"})
+            assert result is True
+            client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retries_on_failure(self, sender: WebhookSender):
+        mock_response_fail = MagicMock()
+        mock_response_fail.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=mock_response_fail,
+            ),
+        )
+
+        mock_response_ok = MagicMock()
+        mock_response_ok.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as MockClient, \
+             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            client = AsyncMock()
+            client.post = AsyncMock(
+                side_effect=[mock_response_fail, mock_response_ok],
+            )
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client
+
+            result = await sender.send({"event": "run.completed"})
+            assert result is True
+            assert client.post.call_count == 2
+            mock_sleep.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_fails_after_max_retries(self, sender: WebhookSender):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=mock_response,
+            ),
+        )
+
+        with patch("httpx.AsyncClient") as MockClient, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            client = AsyncMock()
+            client.post = AsyncMock(return_value=mock_response)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client
+
+            result = await sender.send({"event": "run.failed"})
+            assert result is False
+            assert client.post.call_count == 3  # 3 attempts
+
+    @pytest.mark.asyncio
+    async def test_handles_connection_error(self, sender: WebhookSender):
+        with patch("httpx.AsyncClient") as MockClient, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            client = AsyncMock()
+            client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client
+
+            result = await sender.send({"event": "run.failed"})
+            assert result is False
+            assert client.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_exponential_backoff_delays(self, sender: WebhookSender):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=mock_response,
+            ),
+        )
+
+        with patch("httpx.AsyncClient") as MockClient, \
+             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            client = AsyncMock()
+            client.post = AsyncMock(return_value=mock_response)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client
+
+            await sender.send({"event": "run.failed"})
+            # backoff: 1s, 2s (after 1st and 2nd failure)
+            assert mock_sleep.call_count == 2
+            mock_sleep.assert_any_call(1)
+            mock_sleep.assert_any_call(2)
+
+    @pytest.mark.asyncio
+    async def test_sends_json_payload(self, sender: WebhookSender):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as MockClient:
+            client = AsyncMock()
+            client.post = AsyncMock(return_value=mock_response)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client
+
+            payload = {"event": "run.completed", "run_id": "r1"}
+            await sender.send(payload)
+
+            call_kwargs = client.post.call_args
+            assert call_kwargs[0][0] == "https://example.com/hook"
+            assert call_kwargs[1]["json"] == payload

--- a/tests/unit/test_webhook_integration.py
+++ b/tests/unit/test_webhook_integration.py
@@ -1,0 +1,275 @@
+"""Unit tests for webhook integration with orchestrator."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import yaml
+
+from binex.models.workflow import WebhookConfig, WorkflowSpec
+
+
+# ---- US5: WebhookConfig parsing ----
+
+
+class TestWebhookConfigParsing:
+    def test_parses_from_workflow_yaml(self):
+        """T031: WebhookConfig parses from workflow YAML."""
+        spec_data = {
+            "name": "test-wf",
+            "webhook": {"url": "https://example.com/hook"},
+            "nodes": {
+                "a": {"agent": "llm://gpt-4o", "outputs": ["result"]},
+            },
+        }
+        spec = WorkflowSpec(**spec_data)
+        assert spec.webhook is not None
+        assert spec.webhook.url == "https://example.com/hook"
+
+    def test_webhook_none_when_absent(self):
+        """T032: WebhookConfig is None when absent."""
+        spec_data = {
+            "name": "test-wf",
+            "nodes": {
+                "a": {"agent": "llm://gpt-4o", "outputs": ["result"]},
+            },
+        }
+        spec = WorkflowSpec(**spec_data)
+        assert spec.webhook is None
+
+    def test_parses_from_yaml_string(self):
+        """Parses webhook config from YAML string like real usage."""
+        yaml_str = """
+name: my-pipeline
+webhook:
+  url: "https://hooks.example.com/test"
+nodes:
+  analyze:
+    agent: "llm://gpt-4o"
+    outputs: [result]
+"""
+        data = yaml.safe_load(yaml_str)
+        spec = WorkflowSpec(**data)
+        assert spec.webhook is not None
+        assert spec.webhook.url == "https://hooks.example.com/test"
+
+
+# ---- US5: Orchestrator fires webhook on completion ----
+
+
+class TestWebhookOnCompletion:
+    @pytest.mark.asyncio
+    async def test_fires_run_completed_webhook(self):
+        """T033: orchestrator fires run.completed webhook on successful run."""
+        from binex.runtime.orchestrator import Orchestrator
+        from binex.stores.backends.memory import (
+            InMemoryArtifactStore,
+            InMemoryExecutionStore,
+        )
+
+        exec_store = InMemoryExecutionStore()
+        art_store = InMemoryArtifactStore()
+        orchestrator = Orchestrator(art_store, exec_store)
+
+        # Register a local adapter that returns successfully
+        orchestrator.dispatcher.register_adapter("local://noop", AsyncMock(
+            return_value=AsyncMock(
+                artifacts=[],
+                cost=None,
+            ),
+        ))
+
+        spec = WorkflowSpec(
+            name="test-wf",
+            webhook=WebhookConfig(url="https://example.com/hook"),
+            nodes={
+                "a": {"agent": "local://noop", "outputs": ["result"]},
+            },
+        )
+
+        with patch("binex.runtime.orchestrator.WebhookSender") as MockSender:
+            mock_sender = AsyncMock()
+            mock_sender.send = AsyncMock(return_value=True)
+            MockSender.from_config.return_value = mock_sender
+
+            summary = await orchestrator.run_workflow(spec)
+
+            assert summary.status == "completed"
+            mock_sender.send.assert_called_once()
+            call_payload = mock_sender.send.call_args[0][0]
+            assert call_payload["event"] == "run.completed"
+            assert call_payload["run_id"] == summary.run_id
+            assert call_payload["workflow_name"] == "test-wf"
+            assert call_payload["data"]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_no_webhook_when_not_configured(self):
+        """T034: no webhook when not configured."""
+        from binex.runtime.orchestrator import Orchestrator
+        from binex.stores.backends.memory import (
+            InMemoryArtifactStore,
+            InMemoryExecutionStore,
+        )
+
+        exec_store = InMemoryExecutionStore()
+        art_store = InMemoryArtifactStore()
+        orchestrator = Orchestrator(art_store, exec_store)
+
+        orchestrator.dispatcher.register_adapter("local://noop", AsyncMock(
+            return_value=AsyncMock(
+                artifacts=[],
+                cost=None,
+            ),
+        ))
+
+        spec = WorkflowSpec(
+            name="test-wf",
+            nodes={
+                "a": {"agent": "local://noop", "outputs": ["result"]},
+            },
+        )
+
+        with patch("binex.runtime.orchestrator.WebhookSender") as MockSender:
+            MockSender.from_config.return_value = None
+
+            summary = await orchestrator.run_workflow(spec)
+            assert summary.status == "completed"
+            # from_config was called but returned None, so send should not be called
+            MockSender.from_config.assert_called_once()
+
+
+# ---- US6: Webhook on failure ----
+
+
+class TestWebhookOnFailure:
+    @pytest.mark.asyncio
+    async def test_fires_run_failed_webhook(self):
+        """T041: orchestrator fires run.failed webhook on failed run."""
+        from binex.runtime.orchestrator import Orchestrator
+        from binex.stores.backends.memory import (
+            InMemoryArtifactStore,
+            InMemoryExecutionStore,
+        )
+
+        exec_store = InMemoryExecutionStore()
+        art_store = InMemoryArtifactStore()
+        orchestrator = Orchestrator(art_store, exec_store)
+
+        # Register adapter whose execute method raises
+        failing_adapter = AsyncMock()
+        failing_adapter.execute = AsyncMock(side_effect=RuntimeError("node failed"))
+        orchestrator.dispatcher.register_adapter("local://fail", failing_adapter)
+
+        spec = WorkflowSpec(
+            name="test-wf",
+            webhook=WebhookConfig(url="https://example.com/hook"),
+            nodes={
+                "a": {"agent": "local://fail", "outputs": ["result"]},
+            },
+        )
+
+        with patch("binex.runtime.orchestrator.WebhookSender") as MockSender:
+            mock_sender = AsyncMock()
+            mock_sender.send = AsyncMock(return_value=True)
+            MockSender.from_config.return_value = mock_sender
+
+            summary = await orchestrator.run_workflow(spec)
+
+            assert summary.status == "failed"
+            mock_sender.send.assert_called_once()
+            call_payload = mock_sender.send.call_args[0][0]
+            assert call_payload["event"] == "run.failed"
+            assert call_payload["data"]["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_webhook_retry_on_delivery_failure(self):
+        """T042: webhook retry on delivery failure (3 attempts)."""
+        from binex.webhook import WebhookSender
+
+        sender = WebhookSender(url="https://example.com/hook")
+
+        import httpx
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=mock_response,
+            ),
+        )
+
+        with patch("httpx.AsyncClient") as MockClient, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            client = AsyncMock()
+            client.post = AsyncMock(return_value=mock_response)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client
+
+            result = await sender.send({"event": "run.failed"})
+            assert result is False
+            assert client.post.call_count == 3
+
+
+# ---- US7: Webhook on budget exceeded ----
+
+
+class TestWebhookOnBudgetExceeded:
+    @pytest.mark.asyncio
+    async def test_fires_budget_exceeded_webhook(self):
+        """T046: orchestrator fires run.budget_exceeded webhook on over_budget."""
+        from binex.models.cost import BudgetConfig
+        from binex.runtime.orchestrator import Orchestrator
+        from binex.stores.backends.memory import (
+            InMemoryArtifactStore,
+            InMemoryExecutionStore,
+        )
+
+        exec_store = InMemoryExecutionStore()
+        art_store = InMemoryArtifactStore()
+        orchestrator = Orchestrator(art_store, exec_store)
+
+        # Register adapter that "costs" something
+        from binex.models.cost import CostRecord, ExecutionResult
+
+        async def _execute(task, artifacts, trace_id, **kwargs):
+            cost = CostRecord(
+                id=f"c_{task.node_id}",
+                run_id=task.run_id,
+                task_id=task.node_id,
+                cost=2.0,
+                source="llm_tokens",
+                timestamp=datetime.now(UTC),
+            )
+            return ExecutionResult(artifacts=[], cost=cost)
+
+        expensive_adapter = AsyncMock()
+        expensive_adapter.execute = _execute
+        orchestrator.dispatcher.register_adapter("local://expensive", expensive_adapter)
+
+        spec = WorkflowSpec(
+            name="test-wf",
+            webhook=WebhookConfig(url="https://example.com/hook"),
+            budget=BudgetConfig(max_cost=0.01, policy="stop"),
+            nodes={
+                "a": {"agent": "local://expensive", "outputs": ["r1"]},
+                "b": {"agent": "local://expensive", "outputs": ["r2"],
+                       "depends_on": ["a"]},
+            },
+        )
+
+        with patch("binex.runtime.orchestrator.WebhookSender") as MockSender:
+            mock_sender = AsyncMock()
+            mock_sender.send = AsyncMock(return_value=True)
+            MockSender.from_config.return_value = mock_sender
+
+            summary = await orchestrator.run_workflow(spec)
+
+            assert summary.status == "over_budget"
+            mock_sender.send.assert_called_once()
+            call_payload = mock_sender.send.call_args[0][0]
+            assert call_payload["event"] == "run.budget_exceeded"
+            assert call_payload["data"]["status"] == "over_budget"
+            assert "max_cost" in call_payload["data"]


### PR DESCRIPTION
Add two new features: (1) `binex export` CLI command for exporting run data to CSV or JSON with support for multi-run, artifacts, and custom output directories; (2) webhook notifications on run lifecycle events (completed, failed, budget_exceeded) with retry and exponential backoff.