### PR TITLE
feat: Pattern Nodes — 9 macro-node patterns with sub-DAG expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **Pattern expander** — fixed critical bug where cross-pattern `depends_on` references were not rewired for expanded nodes. When pattern B depended on pattern A, B's entry node still held the stale pattern ID instead of A's exit node after expansion.
+- **CLI test stability** — added `pytest-timeout` (30s) to prevent hanging tests in CI caused by interactive prompts with exhausted input streams.
+- **`has_rich()`** — added `sys.stdout.isatty()` check to prevent Rich from hanging in non-TTY environments (e.g. pytest CliRunner).
+
+### Tests
+
+- Added `TestExpandPatterns` integration tests for `expand_patterns()` covering single pattern expansion, chained patterns, and regular nodes after patterns.
+- Fixed input sequences in `test_explore.py`, `test_start_categories.py` for multi-level interactive menus (`q` vs `Q` semantics).
+- Fixed `result.stderr` property access raising `ValueError` in `test_qa_advanced_debug.py`.
+
 ## v0.6.5
 
 Security, Performance & Observability release.

--- a/examples/patterns/critic.yaml
+++ b/examples/patterns/critic.yaml
@@ -1,0 +1,25 @@
+# Critic pattern: iterative draft → critique → refine
+name: research-with-critic
+description: Research a topic using the Critic pattern for iterative refinement
+nodes:
+  researcher:
+    pattern: critic
+    agent: llm://claude-sonnet-4-6
+    system_prompt: "You are an AI safety researcher."
+    config:
+      rounds: 2
+      steps:
+        draft:
+          model: llm://claude-haiku-4-5
+          prompt: "Write a research summary on the given topic"
+        critique:
+          prompt: "Identify factual errors, logical gaps, and missing perspectives"
+        refine:
+          prompt: "Produce a final version addressing all critique points"
+    outputs: [report]
+
+  publisher:
+    agent: llm://claude-sonnet-4-6
+    depends_on: [researcher]
+    system_prompt: "Format the research report for publication"
+    outputs: [article]

--- a/examples/patterns/debate.yaml
+++ b/examples/patterns/debate.yaml
@@ -1,0 +1,12 @@
+# Debate pattern: multiple agents argue, judge synthesizes
+name: policy-debate
+description: Three AI agents debate a policy question, judge synthesizes
+nodes:
+  debaters:
+    pattern: debate
+    agent: llm://claude-sonnet-4-6
+    system_prompt: "Debate the given policy question"
+    config:
+      agents: 3
+      rounds: 2
+    outputs: [verdict]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ Issues = "https://github.com/Alexli18/binex/issues"
 dev = [
     "pytest",
     "pytest-asyncio",
+    "pytest-timeout",
     "ruff",
     "mypy",
     "mkdocs-material",
@@ -98,3 +99,4 @@ mypy_path = "src"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "--ignore=tests/e2e_playwright"
+timeout = 30

--- a/src/binex/cli/__init__.py
+++ b/src/binex/cli/__init__.py
@@ -40,6 +40,9 @@ def run_async(coro_fn: Callable[..., Coroutine[Any, Any, Any]], *args: Any) -> A
 
 def has_rich() -> bool:
     """Check if the rich library is available and color is not disabled."""
+    import sys
+    if not sys.stdout.isatty():
+        return False
     ctx = click.get_current_context(silent=True)
     if ctx and ctx.color is False:
         return False

--- a/src/binex/models/workflow.py
+++ b/src/binex/models/workflow.py
@@ -77,6 +77,7 @@ class NodeSpec(BaseModel):
 
     id: str = ""
     agent: str
+    pattern: str | None = None
     system_prompt: str | None = None
     inputs: dict[str, Any] = Field(default_factory=dict)
     outputs: list[str]

--- a/src/binex/patterns/__init__.py
+++ b/src/binex/patterns/__init__.py
@@ -1,0 +1,1 @@
+"""Pattern macro-nodes — expand high-level patterns into sub-DAG NodeSpecs."""

--- a/src/binex/patterns/__init__.py
+++ b/src/binex/patterns/__init__.py
@@ -1,1 +1,5 @@
 """Pattern macro-nodes — expand high-level patterns into sub-DAG NodeSpecs."""
+
+from binex.patterns.expander import expand_patterns
+
+__all__ = ["expand_patterns"]

--- a/src/binex/patterns/expander.py
+++ b/src/binex/patterns/expander.py
@@ -65,7 +65,11 @@ def expand_patterns(spec: WorkflowSpec) -> WorkflowSpec:
         return spec  # No patterns, return unchanged
 
     # Rewire depends_on: any node depending on a pattern ID -> depend on exit node
-    for node_id, node in regular_nodes.items():
+    for node in regular_nodes.values():
+        node.depends_on = [
+            pattern_exits.get(dep, dep) for dep in (node.depends_on or [])
+        ]
+    for node in expanded_nodes.values():
         node.depends_on = [
             pattern_exits.get(dep, dep) for dep in (node.depends_on or [])
         ]

--- a/src/binex/patterns/expander.py
+++ b/src/binex/patterns/expander.py
@@ -1,0 +1,87 @@
+"""PatternExpander — finds pattern nodes in a WorkflowSpec and expands them."""
+
+from __future__ import annotations
+
+from binex.models.workflow import BackEdge, WorkflowSpec
+from binex.patterns.models import PatternSpec, StepConfig
+from binex.patterns.templates import expand_pattern
+
+
+def expand_patterns(spec: WorkflowSpec) -> WorkflowSpec:
+    """Find pattern nodes in spec, expand them into sub-DAG nodes."""
+    from binex.models.workflow import NodeSpec
+
+    expanded_nodes: dict[str, NodeSpec] = {}
+    pattern_exits: dict[str, str] = {}  # pattern_id -> exit_node_id
+
+    # Separate pattern nodes from regular nodes
+    regular_nodes: dict[str, NodeSpec] = {}
+    for node_id, node in spec.nodes.items():
+        if node.pattern:
+            # Build steps dict from config if present
+            steps_raw = (node.config or {}).get("steps", {})
+            steps: dict[str, StepConfig] = {}
+            for k, v in steps_raw.items():
+                if isinstance(v, dict):
+                    steps[k] = StepConfig(**v)
+                elif isinstance(v, StepConfig):
+                    steps[k] = v
+
+            pspec = PatternSpec(
+                id=node_id,
+                pattern=node.pattern,
+                model=node.agent,
+                system_prompt=node.system_prompt or "",
+                config={
+                    k: v
+                    for k, v in (node.config or {}).items()
+                    if k != "steps"
+                },
+                steps=steps,
+                depends_on=node.depends_on or [],
+                inputs=node.inputs or {},
+                outputs=node.outputs or [],
+                budget=node.budget,
+            )
+            nodes, edges, back_edges = expand_pattern(pspec)
+            for n in nodes:
+                expanded_nodes[n.id] = n
+
+            # Track exit node for dependency rewiring
+            pattern_exits[node_id] = nodes[-1].id
+
+            # Apply back_edges
+            for be in back_edges:
+                target_node = expanded_nodes[be["node_id"]]
+                target_node.back_edge = BackEdge(
+                    target=be["target"],
+                    when=be.get("when", "true"),
+                    max_iterations=be.get("max_iterations", 5),
+                )
+        else:
+            regular_nodes[node_id] = node
+
+    if not expanded_nodes:
+        return spec  # No patterns, return unchanged
+
+    # Rewire depends_on: any node depending on a pattern ID -> depend on exit node
+    for node_id, node in regular_nodes.items():
+        node.depends_on = [
+            pattern_exits.get(dep, dep) for dep in (node.depends_on or [])
+        ]
+
+    # Merge all nodes
+    all_nodes = {**regular_nodes, **expanded_nodes}
+
+    return WorkflowSpec(
+        version=spec.version,
+        name=spec.name,
+        description=spec.description,
+        nodes=all_nodes,
+        defaults=spec.defaults,
+        budget=spec.budget,
+        webhook=spec.webhook,
+        mcp_servers=spec.mcp_servers,
+        schedule=spec.schedule,
+        source_path=spec.source_path,
+    )

--- a/src/binex/patterns/models.py
+++ b/src/binex/patterns/models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 from typing import Any
+
 from pydantic import BaseModel, field_validator
 
 VALID_PATTERNS = frozenset({

--- a/src/binex/patterns/models.py
+++ b/src/binex/patterns/models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from typing import Any
+from pydantic import BaseModel, field_validator
+
+VALID_PATTERNS = frozenset({
+    "critic", "debate", "best_of_n", "reflexion", "scatter",
+    "fsm", "constitutional", "chain_of_verification", "plan_execute",
+})
+
+class StepConfig(BaseModel):
+    prompt: str | None = None
+    model: str | None = None
+
+class PatternSpec(BaseModel):
+    id: str
+    pattern: str
+    model: str
+    system_prompt: str = ""
+    config: dict[str, Any] = {}
+    steps: dict[str, StepConfig] = {}
+    depends_on: list[str] = []
+    inputs: dict[str, Any] = {}
+    outputs: list[str] = []
+    budget: Any = None
+
+    @field_validator("pattern")
+    @classmethod
+    def validate_pattern(cls, v: str) -> str:
+        if v not in VALID_PATTERNS:
+            raise ValueError(f"Unknown pattern: {v}. Valid: {sorted(VALID_PATTERNS)}")
+        return v

--- a/src/binex/patterns/templates/__init__.py
+++ b/src/binex/patterns/templates/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any
 
 from binex.patterns.templates.best_of_n import expand_best_of_n
 from binex.patterns.templates.chain_of_verification import expand_chain_of_verification
@@ -18,9 +18,9 @@ if TYPE_CHECKING:
     from binex.models.workflow import NodeSpec
     from binex.patterns.models import PatternSpec
 
-ExpandResult = tuple[list["NodeSpec"], list[tuple[str, str]], list[dict]]
+ExpandResult = tuple[list["NodeSpec"], list[tuple[str, str]], list[dict[str, Any]]]
 
-TEMPLATE_REGISTRY: dict[str, Callable] = {
+TEMPLATE_REGISTRY: dict[str, Any] = {
     "critic": expand_critic,
     "debate": expand_debate,
     "best_of_n": expand_best_of_n,
@@ -33,9 +33,10 @@ TEMPLATE_REGISTRY: dict[str, Callable] = {
 }
 
 
-def expand_pattern(spec: "PatternSpec") -> ExpandResult:
+def expand_pattern(spec: PatternSpec) -> ExpandResult:
     """Expand a pattern spec into nodes, edges, and back_edges."""
     fn = TEMPLATE_REGISTRY.get(spec.pattern)
     if fn is None:
         raise ValueError(f"No template for pattern: {spec.pattern}")
-    return fn(spec)
+    result: ExpandResult = fn(spec)
+    return result

--- a/src/binex/patterns/templates/__init__.py
+++ b/src/binex/patterns/templates/__init__.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
+from binex.patterns.templates.best_of_n import expand_best_of_n
+from binex.patterns.templates.chain_of_verification import expand_chain_of_verification
+from binex.patterns.templates.constitutional import expand_constitutional
 from binex.patterns.templates.critic import expand_critic
+from binex.patterns.templates.debate import expand_debate
+from binex.patterns.templates.fsm import expand_fsm
+from binex.patterns.templates.plan_execute import expand_plan_execute
+from binex.patterns.templates.reflexion import expand_reflexion
+from binex.patterns.templates.scatter import expand_scatter
 
 if TYPE_CHECKING:
     from binex.models.workflow import NodeSpec
@@ -14,6 +22,14 @@ ExpandResult = tuple[list["NodeSpec"], list[tuple[str, str]], list[dict]]
 
 TEMPLATE_REGISTRY: dict[str, Callable] = {
     "critic": expand_critic,
+    "debate": expand_debate,
+    "best_of_n": expand_best_of_n,
+    "reflexion": expand_reflexion,
+    "scatter": expand_scatter,
+    "fsm": expand_fsm,
+    "constitutional": expand_constitutional,
+    "chain_of_verification": expand_chain_of_verification,
+    "plan_execute": expand_plan_execute,
 }
 
 

--- a/src/binex/patterns/templates/__init__.py
+++ b/src/binex/patterns/templates/__init__.py
@@ -1,0 +1,25 @@
+"""Pattern template registry and expansion entry point."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from binex.patterns.templates.critic import expand_critic
+
+if TYPE_CHECKING:
+    from binex.models.workflow import NodeSpec
+    from binex.patterns.models import PatternSpec
+
+ExpandResult = tuple[list["NodeSpec"], list[tuple[str, str]], list[dict]]
+
+TEMPLATE_REGISTRY: dict[str, Callable] = {
+    "critic": expand_critic,
+}
+
+
+def expand_pattern(spec: "PatternSpec") -> ExpandResult:
+    """Expand a pattern spec into nodes, edges, and back_edges."""
+    fn = TEMPLATE_REGISTRY.get(spec.pattern)
+    if fn is None:
+        raise ValueError(f"No template for pattern: {spec.pattern}")
+    return fn(spec)

--- a/src/binex/patterns/templates/best_of_n.py
+++ b/src/binex/patterns/templates/best_of_n.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
@@ -13,7 +15,7 @@ DEFAULT_PROMPTS = {
 
 def expand_best_of_n(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand best-of-N pattern into variant_1..N → judge."""
     n_variants = spec.config.get("variants", 3)
     group_meta = {"_pattern_group": spec.id, "_pattern_type": "best_of_n"}
@@ -24,8 +26,9 @@ def expand_best_of_n(
         parts: list[str] = []
         if spec.system_prompt:
             parts.append(spec.system_prompt)
+        default = DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["variant"])
         step_prompt = (
-            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["variant"])
+            step_cfg.prompt if step_cfg and step_cfg.prompt else default
         )
         parts.append(step_prompt)
         return "\n\n".join(parts)

--- a/src/binex/patterns/templates/best_of_n.py
+++ b/src/binex/patterns/templates/best_of_n.py
@@ -1,0 +1,71 @@
+"""Best-of-N pattern template: parallel variants → judge."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPTS = {
+    "variant": "Generate a solution",
+    "judge": "Compare all variants and select the best one",
+}
+
+
+def expand_best_of_n(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand best-of-N pattern into variant_1..N → judge."""
+    n_variants = spec.config.get("variants", 3)
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "best_of_n"}
+    nodes: list[NodeSpec] = []
+
+    def _prompt(step_name: str) -> str:
+        step_cfg = spec.steps.get(step_name)
+        parts: list[str] = []
+        if spec.system_prompt:
+            parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["variant"])
+        )
+        parts.append(step_prompt)
+        return "\n\n".join(parts)
+
+    def _model(step_name: str) -> str:
+        step_cfg = spec.steps.get(step_name)
+        return step_cfg.model if step_cfg and step_cfg.model else spec.model
+
+    # Variant nodes (parallel)
+    variant_ids: list[str] = []
+    for i in range(1, n_variants + 1):
+        step_name = f"variant_{i}"
+        nid = f"{spec.id}.{step_name}"
+        variant_ids.append(nid)
+        nodes.append(NodeSpec(
+            id=nid,
+            agent=_model(step_name),
+            system_prompt=_prompt(step_name),
+            depends_on=list(spec.depends_on),
+            inputs=spec.inputs if i == 1 else {},
+            outputs=["result"],
+            config={**group_meta},
+            budget=spec.budget,
+        ))
+
+    # Judge
+    nodes.append(NodeSpec(
+        id=f"{spec.id}.judge",
+        agent=_model("judge"),
+        system_prompt=_prompt("judge"),
+        depends_on=list(variant_ids),
+        inputs={},
+        outputs=spec.outputs if spec.outputs else ["result"],
+        config={**group_meta},
+        budget=spec.budget,
+    ))
+
+    # Edges
+    edges: list[tuple[str, str]] = []
+    for vid in variant_ids:
+        edges.append((vid, f"{spec.id}.judge"))
+
+    return nodes, edges, []

--- a/src/binex/patterns/templates/chain_of_verification.py
+++ b/src/binex/patterns/templates/chain_of_verification.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
@@ -17,7 +19,7 @@ STEP_ORDER = ("generate", "extract_claims", "verify_each", "revise")
 
 def expand_chain_of_verification(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand chain-of-verification into generate → extract → verify → revise."""
     group_meta = {"_pattern_group": spec.id, "_pattern_type": "chain_of_verification"}
     nodes: list[NodeSpec] = []

--- a/src/binex/patterns/templates/chain_of_verification.py
+++ b/src/binex/patterns/templates/chain_of_verification.py
@@ -1,0 +1,57 @@
+"""Chain-of-Verification pattern: generate → extract_claims → verify_each → revise."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPTS = {
+    "generate": "Generate initial response",
+    "extract_claims": "Extract factual claims from the response",
+    "verify_each": "Verify each claim for accuracy",
+    "revise": "Revise the response correcting any inaccurate claims",
+}
+
+STEP_ORDER = ("generate", "extract_claims", "verify_each", "revise")
+
+
+def expand_chain_of_verification(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand chain-of-verification into generate → extract → verify → revise."""
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "chain_of_verification"}
+    nodes: list[NodeSpec] = []
+
+    for i, step_name in enumerate(STEP_ORDER):
+        step_cfg = spec.steps.get(step_name)
+        model = step_cfg.model if step_cfg and step_cfg.model else spec.model
+        parts: list[str] = []
+        if spec.system_prompt:
+            parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS[step_name]
+        )
+        parts.append(step_prompt)
+
+        deps: list[str]
+        if i == 0:
+            deps = list(spec.depends_on)
+        else:
+            deps = [f"{spec.id}.{STEP_ORDER[i - 1]}"]
+
+        nodes.append(NodeSpec(
+            id=f"{spec.id}.{step_name}",
+            agent=model,
+            system_prompt="\n\n".join(parts),
+            depends_on=deps,
+            inputs=spec.inputs if i == 0 else {},
+            outputs=spec.outputs if step_name == "revise" else ["result"],
+            config={**group_meta},
+            budget=spec.budget,
+        ))
+
+    edges: list[tuple[str, str]] = []
+    for i in range(len(STEP_ORDER) - 1):
+        edges.append((f"{spec.id}.{STEP_ORDER[i]}", f"{spec.id}.{STEP_ORDER[i + 1]}"))
+
+    return nodes, edges, []

--- a/src/binex/patterns/templates/constitutional.py
+++ b/src/binex/patterns/templates/constitutional.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
@@ -14,7 +16,7 @@ DEFAULT_PROMPTS = {
 
 def expand_constitutional(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand constitutional pattern into generate → critique_principles → revise."""
     group_meta = {"_pattern_group": spec.id, "_pattern_type": "constitutional"}
     nodes: list[NodeSpec] = []

--- a/src/binex/patterns/templates/constitutional.py
+++ b/src/binex/patterns/templates/constitutional.py
@@ -1,0 +1,57 @@
+"""Constitutional pattern template: generate → critique_principles → revise."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPTS = {
+    "generate": "Generate initial response",
+    "critique_principles": "Evaluate against constitutional principles",
+    "revise": "Revise to address principle violations",
+}
+
+
+def expand_constitutional(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand constitutional pattern into generate → critique_principles → revise."""
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "constitutional"}
+    nodes: list[NodeSpec] = []
+
+    for i, step_name in enumerate(("generate", "critique_principles", "revise")):
+        step_cfg = spec.steps.get(step_name)
+        model = step_cfg.model if step_cfg and step_cfg.model else spec.model
+        parts: list[str] = []
+        if spec.system_prompt:
+            parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS[step_name]
+        )
+        parts.append(step_prompt)
+
+        deps: list[str]
+        if i == 0:
+            deps = list(spec.depends_on)
+        elif i == 1:
+            deps = [f"{spec.id}.generate"]
+        else:
+            deps = [f"{spec.id}.critique_principles"]
+
+        nodes.append(NodeSpec(
+            id=f"{spec.id}.{step_name}",
+            agent=model,
+            system_prompt="\n\n".join(parts),
+            depends_on=deps,
+            inputs=spec.inputs if i == 0 else {},
+            outputs=spec.outputs if step_name == "revise" else ["result"],
+            config={**group_meta},
+            budget=spec.budget,
+        ))
+
+    edges: list[tuple[str, str]] = [
+        (f"{spec.id}.generate", f"{spec.id}.critique_principles"),
+        (f"{spec.id}.critique_principles", f"{spec.id}.revise"),
+    ]
+
+    return nodes, edges, []

--- a/src/binex/patterns/templates/critic.py
+++ b/src/binex/patterns/templates/critic.py
@@ -1,0 +1,69 @@
+"""Critic pattern template: draft -> critique -> refine expansion."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPTS = {
+    "draft": "Based on the input, produce a thorough draft.",
+    "critique": "Review the draft. List specific weaknesses, gaps, and errors.",
+    "refine": "Revise the draft addressing each critique point.",
+}
+
+
+def expand_critic(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand critic pattern into draft -> critique -> refine nodes."""
+    rounds = spec.config.get("rounds", 1)
+    nodes: list[NodeSpec] = []
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "critic"}
+
+    for step_name in ("draft", "critique", "refine"):
+        step_cfg = spec.steps.get(step_name)
+        model = step_cfg.model if step_cfg and step_cfg.model else spec.model
+        prompt_parts: list[str] = []
+        if spec.system_prompt:
+            prompt_parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt
+            if step_cfg and step_cfg.prompt
+            else DEFAULT_PROMPTS[step_name]
+        )
+        prompt_parts.append(step_prompt)
+
+        node = NodeSpec(
+            id=f"{spec.id}.{step_name}",
+            agent=model,
+            system_prompt="\n\n".join(prompt_parts),
+            depends_on=[],
+            inputs=spec.inputs if step_name == "draft" else {},
+            outputs=spec.outputs if step_name == "refine" else ["result"],
+            config={**group_meta},
+            budget=spec.budget,
+        )
+        nodes.append(node)
+
+    # Wire depends_on
+    nodes[0].depends_on = list(spec.depends_on)  # draft inherits external deps
+    nodes[1].depends_on = [f"{spec.id}.draft"]
+    nodes[2].depends_on = [f"{spec.id}.critique"]
+
+    # Edges
+    edges: list[tuple[str, str]] = [
+        (f"{spec.id}.draft", f"{spec.id}.critique"),
+        (f"{spec.id}.critique", f"{spec.id}.refine"),
+    ]
+
+    # Back-edge for multiple rounds
+    back_edges: list[dict] = []
+    if rounds > 1:
+        back_edges.append({
+            "node_id": f"{spec.id}.refine",
+            "target": f"{spec.id}.draft",
+            "max_iterations": rounds,
+            "when": "true",
+        })
+
+    return nodes, edges, back_edges

--- a/src/binex/patterns/templates/critic.py
+++ b/src/binex/patterns/templates/critic.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
@@ -14,7 +16,7 @@ DEFAULT_PROMPTS = {
 
 def expand_critic(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand critic pattern into draft -> critique -> refine nodes."""
     rounds = spec.config.get("rounds", 1)
     nodes: list[NodeSpec] = []
@@ -57,7 +59,7 @@ def expand_critic(
     ]
 
     # Back-edge for multiple rounds
-    back_edges: list[dict] = []
+    back_edges: list[dict[str, Any]] = []
     if rounds > 1:
         back_edges.append({
             "node_id": f"{spec.id}.refine",

--- a/src/binex/patterns/templates/debate.py
+++ b/src/binex/patterns/templates/debate.py
@@ -1,0 +1,96 @@
+"""Debate pattern template: parallel agents → collector → judge."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPTS = {
+    "agent": "Argue your position on the topic",
+    "collector": "Collect all arguments",
+    "judge": "Evaluate arguments and render a verdict",
+}
+
+
+def expand_debate(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand debate pattern into agent_1..N → collector → judge."""
+    n_agents = spec.config.get("agents", 2)
+    rounds = spec.config.get("rounds", 1)
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "debate"}
+    nodes: list[NodeSpec] = []
+
+    def _prompt(step_name: str) -> str:
+        step_cfg = spec.steps.get(step_name)
+        parts: list[str] = []
+        if spec.system_prompt:
+            parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["agent"])
+        )
+        parts.append(step_prompt)
+        return "\n\n".join(parts)
+
+    def _model(step_name: str) -> str:
+        step_cfg = spec.steps.get(step_name)
+        return step_cfg.model if step_cfg and step_cfg.model else spec.model
+
+    # Agent nodes (parallel)
+    agent_ids: list[str] = []
+    for i in range(1, n_agents + 1):
+        step_name = f"agent_{i}"
+        nid = f"{spec.id}.{step_name}"
+        agent_ids.append(nid)
+        nodes.append(NodeSpec(
+            id=nid,
+            agent=_model(step_name),
+            system_prompt=_prompt(step_name),
+            depends_on=list(spec.depends_on),
+            inputs=spec.inputs if i == 1 else {},
+            outputs=["result"],
+            config={**group_meta},
+            budget=spec.budget,
+        ))
+
+    # Collector
+    nodes.append(NodeSpec(
+        id=f"{spec.id}.collector",
+        agent=_model("collector"),
+        system_prompt=_prompt("collector"),
+        depends_on=list(agent_ids),
+        inputs={},
+        outputs=["result"],
+        config={**group_meta},
+        budget=spec.budget,
+    ))
+
+    # Judge
+    nodes.append(NodeSpec(
+        id=f"{spec.id}.judge",
+        agent=_model("judge"),
+        system_prompt=_prompt("judge"),
+        depends_on=[f"{spec.id}.collector"],
+        inputs={},
+        outputs=spec.outputs if spec.outputs else ["result"],
+        config={**group_meta},
+        budget=spec.budget,
+    ))
+
+    # Edges
+    edges: list[tuple[str, str]] = []
+    for aid in agent_ids:
+        edges.append((aid, f"{spec.id}.collector"))
+    edges.append((f"{spec.id}.collector", f"{spec.id}.judge"))
+
+    # Back-edge for multiple rounds
+    back_edges: list[dict] = []
+    if rounds > 1:
+        back_edges.append({
+            "node_id": f"{spec.id}.judge",
+            "target": agent_ids[0],
+            "max_iterations": rounds,
+            "when": "true",
+        })
+
+    return nodes, edges, back_edges

--- a/src/binex/patterns/templates/debate.py
+++ b/src/binex/patterns/templates/debate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
@@ -14,7 +16,7 @@ DEFAULT_PROMPTS = {
 
 def expand_debate(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand debate pattern into agent_1..N → collector → judge."""
     n_agents = spec.config.get("agents", 2)
     rounds = spec.config.get("rounds", 1)
@@ -26,8 +28,9 @@ def expand_debate(
         parts: list[str] = []
         if spec.system_prompt:
             parts.append(spec.system_prompt)
+        default = DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["agent"])
         step_prompt = (
-            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["agent"])
+            step_cfg.prompt if step_cfg and step_cfg.prompt else default
         )
         parts.append(step_prompt)
         return "\n\n".join(parts)
@@ -84,7 +87,7 @@ def expand_debate(
     edges.append((f"{spec.id}.collector", f"{spec.id}.judge"))
 
     # Back-edge for multiple rounds
-    back_edges: list[dict] = []
+    back_edges: list[dict[str, Any]] = []
     if rounds > 1:
         back_edges.append({
             "node_id": f"{spec.id}.judge",

--- a/src/binex/patterns/templates/fsm.py
+++ b/src/binex/patterns/templates/fsm.py
@@ -1,0 +1,69 @@
+"""FSM pattern template: one node per state, linear chain with back-edges."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPT_TEMPLATE = "{state_name}: Process this state"
+
+
+def expand_fsm(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand FSM pattern into state nodes with linear edges and back-edges."""
+    states: list[str] = spec.config.get("states", ["start", "end"])
+    max_iter = spec.config.get("max_iterations", 3)
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "fsm"}
+    nodes: list[NodeSpec] = []
+
+    def _prompt(state_name: str) -> str:
+        step_cfg = spec.steps.get(state_name)
+        parts: list[str] = []
+        if spec.system_prompt:
+            parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt if step_cfg and step_cfg.prompt
+            else DEFAULT_PROMPT_TEMPLATE.format(state_name=state_name)
+        )
+        parts.append(step_prompt)
+        return "\n\n".join(parts)
+
+    def _model(state_name: str) -> str:
+        step_cfg = spec.steps.get(state_name)
+        return step_cfg.model if step_cfg and step_cfg.model else spec.model
+
+    for i, state in enumerate(states):
+        deps: list[str] = []
+        if i == 0:
+            deps = list(spec.depends_on)
+        else:
+            deps = [f"{spec.id}.{states[i - 1]}"]
+
+        nodes.append(NodeSpec(
+            id=f"{spec.id}.{state}",
+            agent=_model(state),
+            system_prompt=_prompt(state),
+            depends_on=deps,
+            inputs=spec.inputs if i == 0 else {},
+            outputs=spec.outputs if i == len(states) - 1 else ["result"],
+            config={**group_meta},
+            budget=spec.budget,
+        ))
+
+    # Edges: linear chain
+    edges: list[tuple[str, str]] = []
+    for i in range(len(states) - 1):
+        edges.append((f"{spec.id}.{states[i]}", f"{spec.id}.{states[i + 1]}"))
+
+    # Back-edges: each state (except first) can go back to first state
+    back_edges: list[dict] = []
+    for state in states[1:]:
+        back_edges.append({
+            "node_id": f"{spec.id}.{state}",
+            "target": f"{spec.id}.{states[0]}",
+            "max_iterations": max_iter,
+            "when": "true",
+        })
+
+    return nodes, edges, back_edges

--- a/src/binex/patterns/templates/fsm.py
+++ b/src/binex/patterns/templates/fsm.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
@@ -10,7 +12,7 @@ DEFAULT_PROMPT_TEMPLATE = "{state_name}: Process this state"
 
 def expand_fsm(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand FSM pattern into state nodes with linear edges and back-edges."""
     states: list[str] = spec.config.get("states", ["start", "end"])
     max_iter = spec.config.get("max_iterations", 3)
@@ -57,7 +59,7 @@ def expand_fsm(
         edges.append((f"{spec.id}.{states[i]}", f"{spec.id}.{states[i + 1]}"))
 
     # Back-edges: each state (except first) can go back to first state
-    back_edges: list[dict] = []
+    back_edges: list[dict[str, Any]] = []
     for state in states[1:]:
         back_edges.append({
             "node_id": f"{spec.id}.{state}",

--- a/src/binex/patterns/templates/plan_execute.py
+++ b/src/binex/patterns/templates/plan_execute.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
@@ -16,7 +18,7 @@ STEP_ORDER = ("planner", "executor", "verifier")
 
 def expand_plan_execute(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand plan-execute into planner → executor → verifier with back-edge."""
     max_iter = spec.config.get("max_iterations", 3)
     group_meta = {"_pattern_group": spec.id, "_pattern_type": "plan_execute"}
@@ -54,7 +56,7 @@ def expand_plan_execute(
     for i in range(len(STEP_ORDER) - 1):
         edges.append((f"{spec.id}.{STEP_ORDER[i]}", f"{spec.id}.{STEP_ORDER[i + 1]}"))
 
-    back_edges: list[dict] = [{
+    back_edges: list[dict[str, Any]] = [{
         "node_id": f"{spec.id}.verifier",
         "target": f"{spec.id}.planner",
         "max_iterations": max_iter,

--- a/src/binex/patterns/templates/plan_execute.py
+++ b/src/binex/patterns/templates/plan_execute.py
@@ -1,0 +1,64 @@
+"""Plan-Execute pattern: planner → executor → verifier with back-edge."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPTS = {
+    "planner": "Create a step-by-step plan",
+    "executor": "Execute the plan",
+    "verifier": "Verify execution results. Output DONE if satisfactory.",
+}
+
+STEP_ORDER = ("planner", "executor", "verifier")
+
+
+def expand_plan_execute(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand plan-execute into planner → executor → verifier with back-edge."""
+    max_iter = spec.config.get("max_iterations", 3)
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "plan_execute"}
+    nodes: list[NodeSpec] = []
+
+    for i, step_name in enumerate(STEP_ORDER):
+        step_cfg = spec.steps.get(step_name)
+        model = step_cfg.model if step_cfg and step_cfg.model else spec.model
+        parts: list[str] = []
+        if spec.system_prompt:
+            parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS[step_name]
+        )
+        parts.append(step_prompt)
+
+        deps: list[str]
+        if i == 0:
+            deps = list(spec.depends_on)
+        else:
+            deps = [f"{spec.id}.{STEP_ORDER[i - 1]}"]
+
+        nodes.append(NodeSpec(
+            id=f"{spec.id}.{step_name}",
+            agent=model,
+            system_prompt="\n\n".join(parts),
+            depends_on=deps,
+            inputs=spec.inputs if i == 0 else {},
+            outputs=spec.outputs if step_name == "verifier" else ["result"],
+            config={**group_meta},
+            budget=spec.budget,
+        ))
+
+    edges: list[tuple[str, str]] = []
+    for i in range(len(STEP_ORDER) - 1):
+        edges.append((f"{spec.id}.{STEP_ORDER[i]}", f"{spec.id}.{STEP_ORDER[i + 1]}"))
+
+    back_edges: list[dict] = [{
+        "node_id": f"{spec.id}.verifier",
+        "target": f"{spec.id}.planner",
+        "max_iterations": max_iter,
+        "when": "true",
+    }]
+
+    return nodes, edges, back_edges

--- a/src/binex/patterns/templates/reflexion.py
+++ b/src/binex/patterns/templates/reflexion.py
@@ -1,0 +1,72 @@
+"""Reflexion pattern template: actor → reflector with back-edge."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPTS = {
+    "actor": "Attempt the task",
+    "reflector": "Reflect on the attempt. Output DONE if satisfactory, or provide improvement guidance.",
+}
+
+
+def expand_reflexion(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand reflexion pattern into actor → reflector with back-edge."""
+    max_iter = spec.config.get("max_iterations", 3)
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "reflexion"}
+    nodes: list[NodeSpec] = []
+
+    def _prompt(step_name: str) -> str:
+        step_cfg = spec.steps.get(step_name)
+        parts: list[str] = []
+        if spec.system_prompt:
+            parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS[step_name]
+        )
+        parts.append(step_prompt)
+        return "\n\n".join(parts)
+
+    def _model(step_name: str) -> str:
+        step_cfg = spec.steps.get(step_name)
+        return step_cfg.model if step_cfg and step_cfg.model else spec.model
+
+    # Actor
+    nodes.append(NodeSpec(
+        id=f"{spec.id}.actor",
+        agent=_model("actor"),
+        system_prompt=_prompt("actor"),
+        depends_on=list(spec.depends_on),
+        inputs=spec.inputs,
+        outputs=["result"],
+        config={**group_meta},
+        budget=spec.budget,
+    ))
+
+    # Reflector
+    nodes.append(NodeSpec(
+        id=f"{spec.id}.reflector",
+        agent=_model("reflector"),
+        system_prompt=_prompt("reflector"),
+        depends_on=[f"{spec.id}.actor"],
+        inputs={},
+        outputs=spec.outputs if spec.outputs else ["result"],
+        config={**group_meta},
+        budget=spec.budget,
+    ))
+
+    edges: list[tuple[str, str]] = [
+        (f"{spec.id}.actor", f"{spec.id}.reflector"),
+    ]
+
+    back_edges: list[dict] = [{
+        "node_id": f"{spec.id}.reflector",
+        "target": f"{spec.id}.actor",
+        "max_iterations": max_iter,
+        "when": "true",
+    }]
+
+    return nodes, edges, back_edges

--- a/src/binex/patterns/templates/reflexion.py
+++ b/src/binex/patterns/templates/reflexion.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
 DEFAULT_PROMPTS = {
     "actor": "Attempt the task",
-    "reflector": "Reflect on the attempt. Output DONE if satisfactory, or provide improvement guidance.",
+    "reflector": (
+        "Reflect on the attempt. Output DONE if satisfactory, "
+        "or provide improvement guidance."
+    ),
 }
 
 
 def expand_reflexion(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand reflexion pattern into actor → reflector with back-edge."""
     max_iter = spec.config.get("max_iterations", 3)
     group_meta = {"_pattern_group": spec.id, "_pattern_type": "reflexion"}
@@ -62,7 +67,7 @@ def expand_reflexion(
         (f"{spec.id}.actor", f"{spec.id}.reflector"),
     ]
 
-    back_edges: list[dict] = [{
+    back_edges: list[dict[str, Any]] = [{
         "node_id": f"{spec.id}.reflector",
         "target": f"{spec.id}.actor",
         "max_iterations": max_iter,

--- a/src/binex/patterns/templates/scatter.py
+++ b/src/binex/patterns/templates/scatter.py
@@ -1,0 +1,85 @@
+"""Scatter pattern template: mapper → worker_1..N (parallel) → reducer."""
+
+from __future__ import annotations
+
+from binex.models.workflow import NodeSpec
+from binex.patterns.models import PatternSpec
+
+DEFAULT_PROMPTS = {
+    "mapper": "Split the input into sub-tasks",
+    "worker": "Process the assigned sub-task",
+    "reducer": "Combine all worker results",
+}
+
+
+def expand_scatter(
+    spec: PatternSpec,
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+    """Expand scatter pattern into mapper → workers → reducer."""
+    n_workers = spec.config.get("max_workers", 10)
+    group_meta = {"_pattern_group": spec.id, "_pattern_type": "scatter"}
+    nodes: list[NodeSpec] = []
+
+    def _prompt(step_name: str) -> str:
+        step_cfg = spec.steps.get(step_name)
+        parts: list[str] = []
+        if spec.system_prompt:
+            parts.append(spec.system_prompt)
+        step_prompt = (
+            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["worker"])
+        )
+        parts.append(step_prompt)
+        return "\n\n".join(parts)
+
+    def _model(step_name: str) -> str:
+        step_cfg = spec.steps.get(step_name)
+        return step_cfg.model if step_cfg and step_cfg.model else spec.model
+
+    # Mapper
+    nodes.append(NodeSpec(
+        id=f"{spec.id}.mapper",
+        agent=_model("mapper"),
+        system_prompt=_prompt("mapper"),
+        depends_on=list(spec.depends_on),
+        inputs=spec.inputs,
+        outputs=["result"],
+        config={**group_meta},
+        budget=spec.budget,
+    ))
+
+    # Workers (parallel)
+    worker_ids: list[str] = []
+    for i in range(1, n_workers + 1):
+        step_name = f"worker_{i}"
+        nid = f"{spec.id}.{step_name}"
+        worker_ids.append(nid)
+        nodes.append(NodeSpec(
+            id=nid,
+            agent=_model(step_name),
+            system_prompt=_prompt(step_name),
+            depends_on=[f"{spec.id}.mapper"],
+            inputs={},
+            outputs=["result"],
+            config={**group_meta},
+            budget=spec.budget,
+        ))
+
+    # Reducer
+    nodes.append(NodeSpec(
+        id=f"{spec.id}.reducer",
+        agent=_model("reducer"),
+        system_prompt=_prompt("reducer"),
+        depends_on=list(worker_ids),
+        inputs={},
+        outputs=spec.outputs if spec.outputs else ["result"],
+        config={**group_meta},
+        budget=spec.budget,
+    ))
+
+    # Edges
+    edges: list[tuple[str, str]] = []
+    for wid in worker_ids:
+        edges.append((f"{spec.id}.mapper", wid))
+        edges.append((wid, f"{spec.id}.reducer"))
+
+    return nodes, edges, []

--- a/src/binex/patterns/templates/scatter.py
+++ b/src/binex/patterns/templates/scatter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from binex.models.workflow import NodeSpec
 from binex.patterns.models import PatternSpec
 
@@ -14,7 +16,7 @@ DEFAULT_PROMPTS = {
 
 def expand_scatter(
     spec: PatternSpec,
-) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict]]:
+) -> tuple[list[NodeSpec], list[tuple[str, str]], list[dict[str, Any]]]:
     """Expand scatter pattern into mapper → workers → reducer."""
     n_workers = spec.config.get("max_workers", 10)
     group_meta = {"_pattern_group": spec.id, "_pattern_type": "scatter"}
@@ -25,8 +27,9 @@ def expand_scatter(
         parts: list[str] = []
         if spec.system_prompt:
             parts.append(spec.system_prompt)
+        default = DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["worker"])
         step_prompt = (
-            step_cfg.prompt if step_cfg and step_cfg.prompt else DEFAULT_PROMPTS.get(step_name, DEFAULT_PROMPTS["worker"])
+            step_cfg.prompt if step_cfg and step_cfg.prompt else default
         )
         parts.append(step_prompt)
         return "\n\n".join(parts)

--- a/src/binex/workflow_spec/loader.py
+++ b/src/binex/workflow_spec/loader.py
@@ -57,6 +57,8 @@ def load_workflow_from_string(
         spec = WorkflowSpec(**data)
     except ValidationError as exc:
         raise ValueError(f"Invalid workflow spec: {exc}") from exc
+    from binex.patterns import expand_patterns
+    spec = expand_patterns(spec)
     _validate_back_edges(spec)
     return spec
 
@@ -130,6 +132,7 @@ def _resolve_file_prompts(data: dict[str, Any], base_dir: Path | None = None) ->
 
 
 _WHEN_RE = re.compile(r"^\$\{([\w-]+)\.([\w-]+)\}\s*(==|!=)\s*(.+)$")
+_WHEN_LITERALS = frozenset({"true", "false"})
 
 
 def _validate_back_edges(spec: WorkflowSpec) -> None:
@@ -157,7 +160,8 @@ def _validate_back_edges(spec: WorkflowSpec) -> None:
                 f"Node '{node_id}': back_edge target '{be.target}' is not upstream of '{node_id}'"
             )
 
-        if not _WHEN_RE.match(be.when.strip()):
+        when_stripped = be.when.strip()
+        if when_stripped not in _WHEN_LITERALS and not _WHEN_RE.match(when_stripped):
             raise ValueError(
                 f"Node '{node_id}': back_edge has invalid when condition syntax: {be.when!r}"
             )

--- a/tests/unit/test_explore.py
+++ b/tests/unit/test_explore.py
@@ -138,7 +138,7 @@ class TestExploreRunSelection:
         )
         runner = CliRunner()
         with patch(PATCH_TARGET, return_value=stores):
-            result = runner.invoke(cli, ["explore"], input="1\nq\n")
+            result = runner.invoke(cli, ["explore"], input="1\nQ\n")
         assert "Dashboard" in result.output or "dashboard" in result.output.lower()
 
     def test_invalid_choice_reprompts(self):

--- a/tests/unit/test_pattern_expander.py
+++ b/tests/unit/test_pattern_expander.py
@@ -1,6 +1,14 @@
 import pytest
-from binex.patterns.models import PatternSpec
+from binex.patterns.models import PatternSpec, StepConfig
 from binex.patterns.templates.critic import expand_critic
+from binex.patterns.templates.debate import expand_debate
+from binex.patterns.templates.best_of_n import expand_best_of_n
+from binex.patterns.templates.reflexion import expand_reflexion
+from binex.patterns.templates.scatter import expand_scatter
+from binex.patterns.templates.fsm import expand_fsm
+from binex.patterns.templates.constitutional import expand_constitutional
+from binex.patterns.templates.chain_of_verification import expand_chain_of_verification
+from binex.patterns.templates.plan_execute import expand_plan_execute
 
 
 class TestCriticExpansion:
@@ -19,7 +27,6 @@ class TestCriticExpansion:
         assert ("r.critique", "r.refine") in edges
 
     def test_step_model_override(self):
-        from binex.patterns.models import StepConfig
         spec = PatternSpec(
             id="r", pattern="critic", model="llm://claude-sonnet-4-6",
             steps={"draft": StepConfig(model="llm://claude-haiku-4-5", prompt="Quick draft")},
@@ -50,3 +57,394 @@ class TestCriticExpansion:
         nodes, _, _ = expand_critic(spec)
         draft = next(n for n in nodes if n.id == "r.draft")
         assert "upstream" in draft.depends_on
+
+
+class TestDebateExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="d", pattern="debate", model="llm://m")
+        nodes, edges, back_edges = expand_debate(spec)
+        # 2 agents + collector + judge = 4
+        assert len(nodes) == 4
+        ids = {n.id for n in nodes}
+        assert ids == {"d.agent_1", "d.agent_2", "d.collector", "d.judge"}
+
+    def test_edge_wiring(self):
+        spec = PatternSpec(id="d", pattern="debate", model="llm://m")
+        nodes, edges, back_edges = expand_debate(spec)
+        assert ("d.agent_1", "d.collector") in edges
+        assert ("d.agent_2", "d.collector") in edges
+        assert ("d.collector", "d.judge") in edges
+
+    def test_custom_agent_count(self):
+        spec = PatternSpec(id="d", pattern="debate", model="llm://m", config={"agents": 4})
+        nodes, edges, back_edges = expand_debate(spec)
+        assert len(nodes) == 6  # 4 agents + collector + judge
+        agent_ids = {n.id for n in nodes if "agent_" in n.id}
+        assert len(agent_ids) == 4
+
+    def test_model_override(self):
+        spec = PatternSpec(
+            id="d", pattern="debate", model="llm://m",
+            steps={"judge": StepConfig(model="llm://big")},
+        )
+        nodes, _, _ = expand_debate(spec)
+        judge = next(n for n in nodes if n.id == "d.judge")
+        assert judge.agent == "llm://big"
+
+    def test_rounds_back_edge(self):
+        spec = PatternSpec(id="d", pattern="debate", model="llm://m", config={"rounds": 3})
+        nodes, edges, back_edges = expand_debate(spec)
+        assert len(back_edges) == 1
+        be = back_edges[0]
+        assert be["node_id"] == "d.judge"
+        assert be["target"] == "d.agent_1"
+        assert be["max_iterations"] == 3
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="d", pattern="debate", model="llm://m")
+        nodes, _, _ = expand_debate(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "d"
+            assert n.config.get("_pattern_type") == "debate"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="d", pattern="debate", model="llm://m", depends_on=["up"])
+        nodes, _, _ = expand_debate(spec)
+        agent1 = next(n for n in nodes if n.id == "d.agent_1")
+        assert "up" in agent1.depends_on
+
+
+class TestBestOfNExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="b", pattern="best_of_n", model="llm://m")
+        nodes, edges, back_edges = expand_best_of_n(spec)
+        assert len(nodes) == 4  # 3 variants + judge
+        ids = {n.id for n in nodes}
+        assert ids == {"b.variant_1", "b.variant_2", "b.variant_3", "b.judge"}
+
+    def test_edge_wiring(self):
+        spec = PatternSpec(id="b", pattern="best_of_n", model="llm://m")
+        nodes, edges, back_edges = expand_best_of_n(spec)
+        assert ("b.variant_1", "b.judge") in edges
+        assert ("b.variant_2", "b.judge") in edges
+        assert ("b.variant_3", "b.judge") in edges
+        assert len(back_edges) == 0
+
+    def test_custom_variant_count(self):
+        spec = PatternSpec(id="b", pattern="best_of_n", model="llm://m", config={"variants": 5})
+        nodes, edges, back_edges = expand_best_of_n(spec)
+        assert len(nodes) == 6  # 5 variants + judge
+
+    def test_model_override(self):
+        spec = PatternSpec(
+            id="b", pattern="best_of_n", model="llm://m",
+            steps={"judge": StepConfig(model="llm://big")},
+        )
+        nodes, _, _ = expand_best_of_n(spec)
+        judge = next(n for n in nodes if n.id == "b.judge")
+        assert judge.agent == "llm://big"
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="b", pattern="best_of_n", model="llm://m")
+        nodes, _, _ = expand_best_of_n(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "b"
+            assert n.config.get("_pattern_type") == "best_of_n"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="b", pattern="best_of_n", model="llm://m", depends_on=["up"])
+        nodes, _, _ = expand_best_of_n(spec)
+        v1 = next(n for n in nodes if n.id == "b.variant_1")
+        assert "up" in v1.depends_on
+
+
+class TestReflexionExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="rx", pattern="reflexion", model="llm://m")
+        nodes, edges, back_edges = expand_reflexion(spec)
+        assert len(nodes) == 2
+        ids = {n.id for n in nodes}
+        assert ids == {"rx.actor", "rx.reflector"}
+
+    def test_edge_wiring(self):
+        spec = PatternSpec(id="rx", pattern="reflexion", model="llm://m")
+        nodes, edges, back_edges = expand_reflexion(spec)
+        assert ("rx.actor", "rx.reflector") in edges
+
+    def test_back_edge(self):
+        spec = PatternSpec(id="rx", pattern="reflexion", model="llm://m", config={"max_iterations": 5})
+        nodes, edges, back_edges = expand_reflexion(spec)
+        assert len(back_edges) == 1
+        be = back_edges[0]
+        assert be["node_id"] == "rx.reflector"
+        assert be["target"] == "rx.actor"
+        assert be["max_iterations"] == 5
+
+    def test_default_back_edge_iterations(self):
+        spec = PatternSpec(id="rx", pattern="reflexion", model="llm://m")
+        _, _, back_edges = expand_reflexion(spec)
+        assert back_edges[0]["max_iterations"] == 3
+
+    def test_model_override(self):
+        spec = PatternSpec(
+            id="rx", pattern="reflexion", model="llm://m",
+            steps={"reflector": StepConfig(model="llm://big")},
+        )
+        nodes, _, _ = expand_reflexion(spec)
+        reflector = next(n for n in nodes if n.id == "rx.reflector")
+        assert reflector.agent == "llm://big"
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="rx", pattern="reflexion", model="llm://m")
+        nodes, _, _ = expand_reflexion(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "rx"
+            assert n.config.get("_pattern_type") == "reflexion"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="rx", pattern="reflexion", model="llm://m", depends_on=["up"])
+        nodes, _, _ = expand_reflexion(spec)
+        actor = next(n for n in nodes if n.id == "rx.actor")
+        assert "up" in actor.depends_on
+
+
+class TestScatterExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="s", pattern="scatter", model="llm://m", config={"max_workers": 3})
+        nodes, edges, back_edges = expand_scatter(spec)
+        assert len(nodes) == 5  # mapper + 3 workers + reducer
+        ids = {n.id for n in nodes}
+        assert ids == {"s.mapper", "s.worker_1", "s.worker_2", "s.worker_3", "s.reducer"}
+
+    def test_edge_wiring(self):
+        spec = PatternSpec(id="s", pattern="scatter", model="llm://m", config={"max_workers": 2})
+        nodes, edges, back_edges = expand_scatter(spec)
+        assert ("s.mapper", "s.worker_1") in edges
+        assert ("s.mapper", "s.worker_2") in edges
+        assert ("s.worker_1", "s.reducer") in edges
+        assert ("s.worker_2", "s.reducer") in edges
+        assert len(back_edges) == 0
+
+    def test_model_override(self):
+        spec = PatternSpec(
+            id="s", pattern="scatter", model="llm://m", config={"max_workers": 2},
+            steps={"reducer": StepConfig(model="llm://big")},
+        )
+        nodes, _, _ = expand_scatter(spec)
+        reducer = next(n for n in nodes if n.id == "s.reducer")
+        assert reducer.agent == "llm://big"
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="s", pattern="scatter", model="llm://m", config={"max_workers": 2})
+        nodes, _, _ = expand_scatter(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "s"
+            assert n.config.get("_pattern_type") == "scatter"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="s", pattern="scatter", model="llm://m", config={"max_workers": 2}, depends_on=["up"])
+        nodes, _, _ = expand_scatter(spec)
+        mapper = next(n for n in nodes if n.id == "s.mapper")
+        assert "up" in mapper.depends_on
+
+
+class TestFSMExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="f", pattern="fsm", model="llm://m")
+        nodes, edges, back_edges = expand_fsm(spec)
+        assert len(nodes) == 2  # start, end
+        ids = {n.id for n in nodes}
+        assert ids == {"f.start", "f.end"}
+
+    def test_custom_states(self):
+        spec = PatternSpec(id="f", pattern="fsm", model="llm://m", config={"states": ["idle", "active", "done"]})
+        nodes, edges, back_edges = expand_fsm(spec)
+        assert len(nodes) == 3
+        ids = {n.id for n in nodes}
+        assert ids == {"f.idle", "f.active", "f.done"}
+
+    def test_edge_wiring(self):
+        spec = PatternSpec(id="f", pattern="fsm", model="llm://m", config={"states": ["a", "b", "c"]})
+        nodes, edges, back_edges = expand_fsm(spec)
+        assert ("f.a", "f.b") in edges
+        assert ("f.b", "f.c") in edges
+
+    def test_back_edges(self):
+        spec = PatternSpec(id="f", pattern="fsm", model="llm://m", config={"states": ["a", "b", "c"], "max_iterations": 5})
+        nodes, edges, back_edges = expand_fsm(spec)
+        assert len(back_edges) == 2  # b->a and c->a
+        targets = {be["node_id"] for be in back_edges}
+        assert targets == {"f.b", "f.c"}
+        for be in back_edges:
+            assert be["target"] == "f.a"
+            assert be["max_iterations"] == 5
+
+    def test_model_override(self):
+        spec = PatternSpec(
+            id="f", pattern="fsm", model="llm://m",
+            steps={"end": StepConfig(model="llm://big")},
+        )
+        nodes, _, _ = expand_fsm(spec)
+        end = next(n for n in nodes if n.id == "f.end")
+        assert end.agent == "llm://big"
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="f", pattern="fsm", model="llm://m")
+        nodes, _, _ = expand_fsm(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "f"
+            assert n.config.get("_pattern_type") == "fsm"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="f", pattern="fsm", model="llm://m", depends_on=["up"])
+        nodes, _, _ = expand_fsm(spec)
+        start = next(n for n in nodes if n.id == "f.start")
+        assert "up" in start.depends_on
+
+
+class TestConstitutionalExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="c", pattern="constitutional", model="llm://m")
+        nodes, edges, back_edges = expand_constitutional(spec)
+        assert len(nodes) == 3
+        ids = {n.id for n in nodes}
+        assert ids == {"c.generate", "c.critique_principles", "c.revise"}
+        assert len(back_edges) == 0
+
+    def test_edge_wiring(self):
+        spec = PatternSpec(id="c", pattern="constitutional", model="llm://m")
+        nodes, edges, back_edges = expand_constitutional(spec)
+        assert ("c.generate", "c.critique_principles") in edges
+        assert ("c.critique_principles", "c.revise") in edges
+
+    def test_model_override(self):
+        spec = PatternSpec(
+            id="c", pattern="constitutional", model="llm://m",
+            steps={"revise": StepConfig(model="llm://big")},
+        )
+        nodes, _, _ = expand_constitutional(spec)
+        revise = next(n for n in nodes if n.id == "c.revise")
+        assert revise.agent == "llm://big"
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="c", pattern="constitutional", model="llm://m")
+        nodes, _, _ = expand_constitutional(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "c"
+            assert n.config.get("_pattern_type") == "constitutional"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="c", pattern="constitutional", model="llm://m", depends_on=["up"])
+        nodes, _, _ = expand_constitutional(spec)
+        gen = next(n for n in nodes if n.id == "c.generate")
+        assert "up" in gen.depends_on
+
+
+class TestChainOfVerificationExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="cv", pattern="chain_of_verification", model="llm://m")
+        nodes, edges, back_edges = expand_chain_of_verification(spec)
+        assert len(nodes) == 4
+        ids = {n.id for n in nodes}
+        assert ids == {"cv.generate", "cv.extract_claims", "cv.verify_each", "cv.revise"}
+        assert len(back_edges) == 0
+
+    def test_edge_wiring(self):
+        spec = PatternSpec(id="cv", pattern="chain_of_verification", model="llm://m")
+        nodes, edges, back_edges = expand_chain_of_verification(spec)
+        assert ("cv.generate", "cv.extract_claims") in edges
+        assert ("cv.extract_claims", "cv.verify_each") in edges
+        assert ("cv.verify_each", "cv.revise") in edges
+
+    def test_model_override(self):
+        spec = PatternSpec(
+            id="cv", pattern="chain_of_verification", model="llm://m",
+            steps={"verify_each": StepConfig(model="llm://big")},
+        )
+        nodes, _, _ = expand_chain_of_verification(spec)
+        verify = next(n for n in nodes if n.id == "cv.verify_each")
+        assert verify.agent == "llm://big"
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="cv", pattern="chain_of_verification", model="llm://m")
+        nodes, _, _ = expand_chain_of_verification(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "cv"
+            assert n.config.get("_pattern_type") == "chain_of_verification"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="cv", pattern="chain_of_verification", model="llm://m", depends_on=["up"])
+        nodes, _, _ = expand_chain_of_verification(spec)
+        gen = next(n for n in nodes if n.id == "cv.generate")
+        assert "up" in gen.depends_on
+
+
+class TestPlanExecuteExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="pe", pattern="plan_execute", model="llm://m")
+        nodes, edges, back_edges = expand_plan_execute(spec)
+        assert len(nodes) == 3
+        ids = {n.id for n in nodes}
+        assert ids == {"pe.planner", "pe.executor", "pe.verifier"}
+
+    def test_edge_wiring(self):
+        spec = PatternSpec(id="pe", pattern="plan_execute", model="llm://m")
+        nodes, edges, back_edges = expand_plan_execute(spec)
+        assert ("pe.planner", "pe.executor") in edges
+        assert ("pe.executor", "pe.verifier") in edges
+
+    def test_back_edge(self):
+        spec = PatternSpec(id="pe", pattern="plan_execute", model="llm://m", config={"max_iterations": 5})
+        nodes, edges, back_edges = expand_plan_execute(spec)
+        assert len(back_edges) == 1
+        be = back_edges[0]
+        assert be["node_id"] == "pe.verifier"
+        assert be["target"] == "pe.planner"
+        assert be["max_iterations"] == 5
+
+    def test_default_back_edge_iterations(self):
+        spec = PatternSpec(id="pe", pattern="plan_execute", model="llm://m")
+        _, _, back_edges = expand_plan_execute(spec)
+        assert back_edges[0]["max_iterations"] == 3
+
+    def test_model_override(self):
+        spec = PatternSpec(
+            id="pe", pattern="plan_execute", model="llm://m",
+            steps={"executor": StepConfig(model="llm://big")},
+        )
+        nodes, _, _ = expand_plan_execute(spec)
+        executor = next(n for n in nodes if n.id == "pe.executor")
+        assert executor.agent == "llm://big"
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="pe", pattern="plan_execute", model="llm://m")
+        nodes, _, _ = expand_plan_execute(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "pe"
+            assert n.config.get("_pattern_type") == "plan_execute"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="pe", pattern="plan_execute", model="llm://m", depends_on=["up"])
+        nodes, _, _ = expand_plan_execute(spec)
+        planner = next(n for n in nodes if n.id == "pe.planner")
+        assert "up" in planner.depends_on
+
+
+class TestTemplateRegistry:
+    def test_all_patterns_registered(self):
+        from binex.patterns.templates import TEMPLATE_REGISTRY
+        expected = {"critic", "debate", "best_of_n", "reflexion", "scatter", "fsm", "constitutional", "chain_of_verification", "plan_execute"}
+        assert set(TEMPLATE_REGISTRY.keys()) == expected
+
+    def test_expand_pattern_dispatches(self):
+        from binex.patterns.templates import expand_pattern
+        spec = PatternSpec(id="t", pattern="debate", model="llm://m")
+        nodes, edges, back_edges = expand_pattern(spec)
+        assert len(nodes) == 4  # debate default: 2 agents + collector + judge
+
+    def test_expand_pattern_unknown_raises(self):
+        from binex.patterns.templates import expand_pattern
+        # Bypass PatternSpec validation to test registry error handling
+        spec = PatternSpec.model_construct(id="t", pattern="nonexistent", model="llm://m")
+        with pytest.raises(ValueError, match="No template for pattern"):
+            expand_pattern(spec)

--- a/tests/unit/test_pattern_expander.py
+++ b/tests/unit/test_pattern_expander.py
@@ -430,6 +430,79 @@ class TestPlanExecuteExpansion:
         assert "up" in planner.depends_on
 
 
+class TestExpandPatterns:
+    """Integration tests for expand_patterns() at WorkflowSpec level."""
+
+    def _make_spec(self, nodes_raw: dict) -> "WorkflowSpec":
+        from binex.models.workflow import WorkflowSpec
+        import yaml, textwrap
+        # Build minimal WorkflowSpec from node dicts
+        nodes = {}
+        for node_id, cfg in nodes_raw.items():
+            from binex.models.workflow import NodeSpec
+            nodes[node_id] = NodeSpec(**cfg)
+        return WorkflowSpec(version="1.0", name="test", nodes=nodes)
+
+    def _pattern_node(self, pattern: str, depends_on: list[str] | None = None):
+        from binex.models.workflow import NodeSpec
+        return NodeSpec(agent="llm://m", pattern=pattern, outputs=[], depends_on=depends_on or [])
+
+    def _regular_node(self, depends_on: list[str] | None = None):
+        from binex.models.workflow import NodeSpec
+        return NodeSpec(agent="llm://m", outputs=[], depends_on=depends_on or [])
+
+    def test_single_pattern_expands(self):
+        from binex.patterns.expander import expand_patterns
+        from binex.models.workflow import WorkflowSpec
+        spec = WorkflowSpec(
+            version="1.0", name="t",
+            nodes={"a": self._pattern_node("critic")},
+        )
+        result = expand_patterns(spec)
+        assert "a" not in result.nodes
+        assert "a.draft" in result.nodes
+        assert "a.refine" in result.nodes
+
+    def test_chained_patterns_rewired(self):
+        """Pattern B depends on pattern A — B's entry must depend on A's exit, not 'a'."""
+        from binex.patterns.expander import expand_patterns
+        from binex.models.workflow import WorkflowSpec
+        spec = WorkflowSpec(
+            version="1.0", name="t",
+            nodes={
+                "a": self._pattern_node("critic"),
+                "b": self._pattern_node("debate", depends_on=["a"]),
+            },
+        )
+        result = expand_patterns(spec)
+        assert "a" not in result.nodes
+        assert "b" not in result.nodes
+        # Critic exit = a.refine; debate entry = b.agent_1
+        b_entry = result.nodes["b.agent_1"]
+        assert "a.refine" in b_entry.depends_on, (
+            f"b.agent_1.depends_on should contain 'a.refine', got {b_entry.depends_on}"
+        )
+        assert "a" not in b_entry.depends_on, (
+            f"Stale pattern ID 'a' still in b.agent_1.depends_on: {b_entry.depends_on}"
+        )
+
+    def test_regular_node_after_pattern_rewired(self):
+        """A regular node depending on a pattern should depend on the exit node."""
+        from binex.patterns.expander import expand_patterns
+        from binex.models.workflow import WorkflowSpec
+        spec = WorkflowSpec(
+            version="1.0", name="t",
+            nodes={
+                "a": self._pattern_node("critic"),
+                "sink": self._regular_node(depends_on=["a"]),
+            },
+        )
+        result = expand_patterns(spec)
+        sink = result.nodes["sink"]
+        assert "a.refine" in sink.depends_on
+        assert "a" not in sink.depends_on
+
+
 class TestTemplateRegistry:
     def test_all_patterns_registered(self):
         from binex.patterns.templates import TEMPLATE_REGISTRY

--- a/tests/unit/test_pattern_expander.py
+++ b/tests/unit/test_pattern_expander.py
@@ -1,0 +1,52 @@
+import pytest
+from binex.patterns.models import PatternSpec
+from binex.patterns.templates.critic import expand_critic
+
+
+class TestCriticExpansion:
+    def test_basic_expansion(self):
+        spec = PatternSpec(id="r", pattern="critic", model="llm://claude-sonnet-4-6")
+        nodes, edges, back_edges = expand_critic(spec)
+
+        assert len(nodes) == 3
+        ids = {n.id for n in nodes}
+        assert ids == {"r.draft", "r.critique", "r.refine"}
+
+        for n in nodes:
+            assert n.agent == "llm://claude-sonnet-4-6"
+
+        assert ("r.draft", "r.critique") in edges
+        assert ("r.critique", "r.refine") in edges
+
+    def test_step_model_override(self):
+        from binex.patterns.models import StepConfig
+        spec = PatternSpec(
+            id="r", pattern="critic", model="llm://claude-sonnet-4-6",
+            steps={"draft": StepConfig(model="llm://claude-haiku-4-5", prompt="Quick draft")},
+        )
+        nodes, edges, back_edges = expand_critic(spec)
+        draft = next(n for n in nodes if n.id == "r.draft")
+        assert draft.agent == "llm://claude-haiku-4-5"
+        assert "Quick draft" in draft.system_prompt
+
+    def test_rounds_create_back_edge(self):
+        spec = PatternSpec(id="r", pattern="critic", model="llm://m", config={"rounds": 3})
+        nodes, edges, back_edges = expand_critic(spec)
+        assert len(back_edges) == 1
+        be = back_edges[0]
+        assert be["node_id"] == "r.refine"
+        assert be["target"] == "r.draft"
+        assert be["max_iterations"] == 3
+
+    def test_group_metadata(self):
+        spec = PatternSpec(id="r", pattern="critic", model="llm://m")
+        nodes, _, _ = expand_critic(spec)
+        for n in nodes:
+            assert n.config.get("_pattern_group") == "r"
+            assert n.config.get("_pattern_type") == "critic"
+
+    def test_external_depends_wired_to_entry(self):
+        spec = PatternSpec(id="r", pattern="critic", model="llm://m", depends_on=["upstream"])
+        nodes, _, _ = expand_critic(spec)
+        draft = next(n for n in nodes if n.id == "r.draft")
+        assert "upstream" in draft.depends_on

--- a/tests/unit/test_pattern_integration.py
+++ b/tests/unit/test_pattern_integration.py
@@ -1,0 +1,57 @@
+import pytest
+from binex.workflow_spec.loader import load_workflow_from_string
+
+CRITIC_YAML = """
+name: test-critic
+nodes:
+  researcher:
+    pattern: critic
+    agent: llm://claude-sonnet-4-6
+    system_prompt: "Research AI safety"
+    config:
+      rounds: 2
+    outputs: [report]
+  writer:
+    agent: llm://claude-sonnet-4-6
+    depends_on: [researcher]
+    system_prompt: "Write article from research"
+    outputs: [article]
+"""
+
+
+class TestPatternYAMLIntegration:
+    def test_critic_expands_in_workflow(self):
+        spec = load_workflow_from_string(CRITIC_YAML, fmt="yaml")
+        # Pattern node replaced by 3 sub-nodes
+        assert "researcher" not in spec.nodes
+        assert "researcher.draft" in spec.nodes
+        assert "researcher.critique" in spec.nodes
+        assert "researcher.refine" in spec.nodes
+        # Writer depends on exit node
+        assert "researcher.refine" in spec.nodes["writer"].depends_on
+
+    def test_dag_builds_after_expansion(self):
+        from binex.graph.dag import DAG
+        spec = load_workflow_from_string(CRITIC_YAML, fmt="yaml")
+        dag = DAG.from_workflow(spec)
+        order = dag.topological_order()
+        assert order.index("researcher.draft") < order.index("researcher.critique")
+        assert order.index("researcher.critique") < order.index("researcher.refine")
+        assert order.index("researcher.refine") < order.index("writer")
+
+    def test_no_pattern_nodes_unchanged(self):
+        plain_yaml = """
+name: test-plain
+nodes:
+  a:
+    agent: llm://m
+    outputs: [x]
+  b:
+    agent: llm://m
+    depends_on: [a]
+    outputs: [y]
+"""
+        spec = load_workflow_from_string(plain_yaml, fmt="yaml")
+        assert "a" in spec.nodes
+        assert "b" in spec.nodes
+        assert len(spec.nodes) == 2

--- a/tests/unit/test_pattern_models.py
+++ b/tests/unit/test_pattern_models.py
@@ -1,0 +1,39 @@
+import pytest
+from binex.patterns.models import PatternSpec, StepConfig
+
+class TestStepConfig:
+    def test_minimal(self):
+        s = StepConfig(prompt="Do the thing")
+        assert s.prompt == "Do the thing"
+        assert s.model is None
+
+    def test_with_model_override(self):
+        s = StepConfig(prompt="Draft it", model="llm://claude-haiku-4-5")
+        assert s.model == "llm://claude-haiku-4-5"
+
+class TestPatternSpec:
+    def test_critic_minimal(self):
+        p = PatternSpec(id="researcher", pattern="critic", model="llm://claude-sonnet-4-6")
+        assert p.pattern == "critic"
+        assert p.config == {}
+        assert p.steps == {}
+
+    def test_critic_with_steps(self):
+        p = PatternSpec(
+            id="researcher",
+            pattern="critic",
+            model="llm://claude-sonnet-4-6",
+            system_prompt="Research X",
+            config={"rounds": 2},
+            steps={"draft": StepConfig(model="llm://claude-haiku-4-5", prompt="Write draft")},
+        )
+        assert p.config["rounds"] == 2
+        assert p.steps["draft"].model == "llm://claude-haiku-4-5"
+
+    def test_unknown_pattern_rejected(self):
+        with pytest.raises(ValueError, match="Unknown pattern"):
+            PatternSpec(id="x", pattern="nonexistent", model="llm://m")
+
+    def test_debate_requires_agents_count(self):
+        p = PatternSpec(id="d", pattern="debate", model="llm://m", config={"agents": 3})
+        assert p.config["agents"] == 3

--- a/tests/unit/test_qa_advanced_debug.py
+++ b/tests/unit/test_qa_advanced_debug.py
@@ -636,8 +636,11 @@ class TestCLIDiagnose:
             result = runner.invoke(cli, ["diagnose", "run_nonexistent", "--json"])
 
         assert result.exit_code != 0
-        full = result.output + str(getattr(result, "stderr", ""))
-        assert "not found" in full
+        try:
+            stderr_text = result.stderr
+        except ValueError:
+            stderr_text = ""
+        assert "not found" in result.output + stderr_text
 
     def test_diag_026_diagnose_no_rich_forces_plain(self, runner):
         """TC-DIAG-026: binex diagnose --no-rich forces plain text output."""
@@ -694,7 +697,11 @@ class TestCLIBisect:
             result = runner.invoke(cli, ["bisect", "good_01", "bad_01", "--json"])
 
         assert result.exit_code != 0
-        assert "not found" in result.output or "not found" in str(getattr(result, "stderr", ""))
+        try:
+            stderr_text = result.stderr
+        except ValueError:
+            stderr_text = ""
+        assert "not found" in result.output + stderr_text
 
     def test_bsct_013_bisect_custom_threshold(self, runner):
         """TC-BSCT-013: binex bisect --threshold 0.5 custom threshold."""

--- a/tests/unit/test_start_categories.py
+++ b/tests/unit/test_start_categories.py
@@ -1,5 +1,7 @@
 """Tests for category navigation in binex start wizard."""
 
+from unittest.mock import patch
+
 from click.testing import CliRunner
 
 from binex.cli.start import start_cmd
@@ -9,7 +11,6 @@ def test_start_shows_categories():
     """Invoking start should display category names like General and Development."""
     runner = CliRunner()
     result = runner.invoke(start_cmd, input="q\n")
-    # Should show at least some category names before any input
     assert "General" in result.output or "general" in result.output.lower()
     assert "Development" in result.output or "development" in result.output.lower()
 
@@ -17,8 +18,8 @@ def test_start_shows_categories():
 def test_start_category_then_template():
     """Selecting a category should show its templates."""
     runner = CliRunner()
-    # Select category 2 (Development), then quit
-    result = runner.invoke(start_cmd, input="2\nq\n")
+    # Select category 2 (Development), then q to go back, then q to quit
+    result = runner.invoke(start_cmd, input="2\nq\nq\n")
     output = result.output
     assert "Code Review" in output or "code-review" in output.lower()
 
@@ -26,10 +27,8 @@ def test_start_category_then_template():
 def test_start_back_from_templates():
     """Pressing 'b' from template list returns to categories."""
     runner = CliRunner()
-    # Select category 2, then 'b' to go back, then 'q' to quit
     result = runner.invoke(start_cmd, input="2\nb\nq\n")
     output = result.output
-    # Categories should appear twice (initial + after back)
     first = output.find("General")
     if first == -1:
         first = output.lower().find("general")
@@ -42,7 +41,7 @@ def test_start_back_from_templates():
 def test_start_constructor_shortcut():
     """Pressing 'c' should enter constructor mode."""
     runner = CliRunner()
-    # Press 'c' for constructor, then quit
-    result = runner.invoke(start_cmd, input="c\ndone\n")
-    output = result.lower() if hasattr(result, 'lower') else result.output.lower()
+    with patch("binex.cli.start._step_custom_template", side_effect=SystemExit(0)):
+        result = runner.invoke(start_cmd, input="c\n")
+    output = result.output.lower()
     assert "constructor" in output or "dsl" in output or "topology" in output

--- a/ui/src/components/dag/CustomNode.tsx
+++ b/ui/src/components/dag/CustomNode.tsx
@@ -29,6 +29,11 @@ export function CustomNode({ data }: NodeProps<WorkflowNode>) {
       {data.status && (
         <div className={`text-xs mt-1 capitalize ${statusTokens.text}`}>{data.status}</div>
       )}
+      {data.patternGroup && (
+        <div className="text-[9px] text-pink-400 mt-0.5 truncate">
+          ⬡ {data.patternType ?? 'pattern'}
+        </div>
+      )}
       <Handle type="source" position={Position.Bottom} className="!bg-slate-500 !border-slate-400" />
     </div>
   );

--- a/ui/src/components/dag/PatternGroup.tsx
+++ b/ui/src/components/dag/PatternGroup.tsx
@@ -1,0 +1,58 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+// Icon map for pattern types
+const PATTERN_LABELS: Record<string, string> = {
+  critic: 'Critic',
+  debate: 'Debate',
+  best_of_n: 'Best of N',
+  reflexion: 'Reflexion',
+  scatter: 'Scatter',
+  fsm: 'State Machine',
+  constitutional: 'Constitutional',
+  chain_of_verification: 'Verify Chain',
+  plan_execute: 'Plan & Execute',
+};
+
+interface PatternGroupProps {
+  groupId: string;
+  patternType: string;
+  childCount: number;
+  collapsed: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}
+
+export function PatternGroup({
+  groupId,
+  patternType,
+  childCount,
+  collapsed,
+  onToggle,
+  children,
+}: PatternGroupProps) {
+  const label = PATTERN_LABELS[patternType] ?? patternType;
+
+  return (
+    <div className="relative rounded-lg border-2 border-dashed border-pink-500/40 bg-pink-950/10 p-2">
+      {/* Header */}
+      <button
+        onClick={onToggle}
+        className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-pink-900/20 transition-colors text-left w-full"
+      >
+        {collapsed ? (
+          <ChevronRight size={14} className="text-pink-400" />
+        ) : (
+          <ChevronDown size={14} className="text-pink-400" />
+        )}
+        <span className="text-xs font-medium text-pink-300">{label}</span>
+        <span className="text-[10px] text-pink-500 ml-1">({groupId})</span>
+        {collapsed && (
+          <span className="text-[10px] text-slate-500 ml-auto">{childCount} nodes</span>
+        )}
+      </button>
+
+      {/* Children */}
+      {!collapsed && <div className="mt-1">{children}</div>}
+    </div>
+  );
+}

--- a/ui/src/components/editor/EditableNode.tsx
+++ b/ui/src/components/editor/EditableNode.tsx
@@ -8,6 +8,7 @@ import { ToolChip } from './ToolChip';
 import { ToolPickerPopover } from './ToolPickerPopover';
 import { PromptLibraryPanel } from '../../pages/PromptLibrary';
 import { CaoNodePanel } from './CaoNodePanel';
+import { PatternConfig } from './PatternConfig';
 
 const ICONS: Record<string, React.ElementType> = {
   llm: Bot, local: Monitor, 'human-approve': ShieldCheck,
@@ -300,6 +301,16 @@ function EditableNodeInner({ data, id, selected }: NodeProps<EditableNodeData>) 
             config={config}
             onAgentChange={updateAgent}
             onConfigChange={updateConfig}
+          />
+        )}
+
+        {agent.startsWith('pattern://') && (
+          <PatternConfig
+            patternType={agent.replace('pattern://', '')}
+            config={config}
+            onChange={(newConfig) => {
+              Object.entries(newConfig).forEach(([k, v]) => updateConfig(k, v));
+            }}
           />
         )}
       </div>

--- a/ui/src/components/editor/NodePalette.tsx
+++ b/ui/src/components/editor/NodePalette.tsx
@@ -1,4 +1,4 @@
-import { Bot, Monitor, ShieldCheck, MessageSquare, Globe, Eye, Terminal } from 'lucide-react';
+import { Bot, Monitor, ShieldCheck, MessageSquare, Globe, Eye, Terminal, Repeat, Users, Trophy, RefreshCw, GitBranch, Workflow, Scale, CheckCheck, ListChecks } from 'lucide-react';
 import { chartColors } from '@/lib/design-tokens';
 
 export interface NodeTypeConfig {
@@ -20,6 +20,7 @@ const NODE_COLOR = {
   human: '#f59e0b',   // amber-500
   a2a: '#6366f1',     // indigo-500
   cao: chartColors.cao, // purple-500
+  pattern: '#ec4899',   // pink-500
 } as const;
 
 export const NODE_TYPES: NodeTypeConfig[] = [
@@ -30,6 +31,16 @@ export const NODE_TYPES: NodeTypeConfig[] = [
   { type: 'human-output', subtype: 'output', label: 'Output', description: 'Display results', icon: Eye, color: NODE_COLOR.human, agentPrefix: 'human://', defaultAgent: 'human://output' },
   { type: 'a2a', label: 'A2A Agent', description: 'Remote agent', icon: Globe, color: NODE_COLOR.a2a, agentPrefix: 'a2a://', defaultAgent: 'a2a://localhost:8001' },
   { type: 'cao', label: 'CAO Agent', description: 'CLI orchestrator', icon: Terminal, color: NODE_COLOR.cao, agentPrefix: 'cao://', defaultAgent: 'cao://default', category: 'CLI AGENTS' },
+  // Patterns
+  { type: 'pattern-critic', label: 'Critic', description: 'Draft→critique→refine', icon: Repeat, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://critic', category: 'PATTERNS' },
+  { type: 'pattern-debate', label: 'Debate', description: 'Multi-agent debate', icon: Users, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://debate', category: 'PATTERNS' },
+  { type: 'pattern-best_of_n', label: 'Best of N', description: 'Generate N, pick best', icon: Trophy, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://best_of_n', category: 'PATTERNS' },
+  { type: 'pattern-reflexion', label: 'Reflexion', description: 'Act→reflect loop', icon: RefreshCw, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://reflexion', category: 'PATTERNS' },
+  { type: 'pattern-scatter', label: 'Scatter', description: 'Map→workers→reduce', icon: GitBranch, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://scatter', category: 'PATTERNS' },
+  { type: 'pattern-fsm', label: 'State Machine', description: 'Finite state machine', icon: Workflow, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://fsm', category: 'PATTERNS' },
+  { type: 'pattern-constitutional', label: 'Constitutional', description: 'Principle-guided AI', icon: Scale, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://constitutional', category: 'PATTERNS' },
+  { type: 'pattern-chain_of_verification', label: 'Verify Chain', description: 'Generate→verify→revise', icon: CheckCheck, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://chain_of_verification', category: 'PATTERNS' },
+  { type: 'pattern-plan_execute', label: 'Plan & Execute', description: 'Plan→execute→verify', icon: ListChecks, color: NODE_COLOR.pattern, agentPrefix: 'pattern://', defaultAgent: 'pattern://plan_execute', category: 'PATTERNS' },
 ];
 
 export function NodePalette() {
@@ -40,6 +51,7 @@ export function NodePalette() {
 
   const defaultNodes = NODE_TYPES.filter((nt) => !nt.category);
   const cliAgents = NODE_TYPES.filter((nt) => nt.category === 'CLI AGENTS');
+  const patternNodes = NODE_TYPES.filter((nt) => nt.category === 'PATTERNS');
 
   const renderItem = (nt: NodeTypeConfig) => {
     const Icon = nt.icon;
@@ -73,6 +85,14 @@ export function NodePalette() {
             CLI
           </div>
           {cliAgents.map(renderItem)}
+        </>
+      )}
+      {patternNodes.length > 0 && (
+        <>
+          <div className="px-2 pt-2 py-1 text-[10px] font-medium text-slate-500 uppercase tracking-wider border-t border-slate-700/30 mt-1">
+            Patterns
+          </div>
+          {patternNodes.map(renderItem)}
         </>
       )}
       <div className="mt-auto px-2 py-1.5 text-[9px] text-slate-600">

--- a/ui/src/components/editor/PatternConfig.tsx
+++ b/ui/src/components/editor/PatternConfig.tsx
@@ -1,0 +1,111 @@
+import { CollapsibleSection } from './CollapsibleSection';
+
+// Pattern-specific config fields
+const PATTERN_CONFIG: Record<string, { label: string; fields: Array<{ key: string; label: string; type: 'number' | 'text'; default: number | string }> }> = {
+  critic: {
+    label: 'Critic',
+    fields: [
+      { key: 'rounds', label: 'Rounds', type: 'number', default: 1 },
+    ],
+  },
+  debate: {
+    label: 'Debate',
+    fields: [
+      { key: 'agents', label: 'Agents', type: 'number', default: 2 },
+      { key: 'rounds', label: 'Rounds', type: 'number', default: 1 },
+    ],
+  },
+  best_of_n: {
+    label: 'Best of N',
+    fields: [
+      { key: 'variants', label: 'Variants', type: 'number', default: 3 },
+    ],
+  },
+  reflexion: {
+    label: 'Reflexion',
+    fields: [
+      { key: 'max_iterations', label: 'Max Iterations', type: 'number', default: 3 },
+    ],
+  },
+  scatter: {
+    label: 'Scatter',
+    fields: [
+      { key: 'max_workers', label: 'Max Workers', type: 'number', default: 10 },
+    ],
+  },
+  fsm: {
+    label: 'State Machine',
+    fields: [
+      { key: 'max_iterations', label: 'Max Iterations', type: 'number', default: 10 },
+    ],
+  },
+  constitutional: {
+    label: 'Constitutional',
+    fields: [],
+  },
+  chain_of_verification: {
+    label: 'Verify Chain',
+    fields: [],
+  },
+  plan_execute: {
+    label: 'Plan & Execute',
+    fields: [
+      { key: 'max_iterations', label: 'Max Iterations', type: 'number', default: 3 },
+    ],
+  },
+};
+
+interface PatternConfigProps {
+  patternType: string;
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+}
+
+export function PatternConfig({ patternType, config, onChange }: PatternConfigProps) {
+  const patternDef = PATTERN_CONFIG[patternType];
+  if (!patternDef) return null;
+
+  const handleFieldChange = (key: string, value: string) => {
+    const field = patternDef.fields.find((f) => f.key === key);
+    const parsed = field?.type === 'number' ? Number(value) : value;
+    onChange({ ...config, [key]: parsed });
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Pattern type badge */}
+      <div className="flex items-center gap-2">
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-pink-900/40 text-pink-300 border border-pink-700/30">
+          {patternDef.label}
+        </span>
+      </div>
+
+      {/* Pattern-specific fields */}
+      {patternDef.fields.length > 0 && (
+        <CollapsibleSection title="Pattern Config" defaultOpen>
+          <div className="space-y-2">
+            {patternDef.fields.map((field) => (
+              <label key={field.key} className="flex items-center justify-between gap-2">
+                <span className="text-[11px] text-slate-400">{field.label}</span>
+                <input
+                  type={field.type}
+                  value={(config[field.key] as string | number) ?? field.default}
+                  onChange={(e) => handleFieldChange(field.key, e.target.value)}
+                  className="w-16 px-1.5 py-0.5 text-[11px] bg-slate-800 border border-slate-700 rounded text-slate-200 text-right"
+                  min={field.type === 'number' ? 1 : undefined}
+                />
+              </label>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Steps section (per-step model/prompt overrides) */}
+      <CollapsibleSection title="Step Overrides">
+        <p className="text-[10px] text-slate-500">
+          Configure per-step model and prompt overrides in the YAML editor.
+        </p>
+      </CollapsibleSection>
+    </div>
+  );
+}

--- a/ui/src/lib/design-tokens.ts
+++ b/ui/src/lib/design-tokens.ts
@@ -98,6 +98,12 @@ export const nodeTypeColors = {
     border: 'border-purple-500/40',
     icon: 'text-purple-400',
   },
+  pattern: {
+    bg: 'bg-pink-500/15',
+    text: 'text-pink-400',
+    border: 'border-pink-500/40',
+    icon: 'text-pink-400',
+  },
 } as const;
 
 export type NodeType = keyof typeof nodeTypeColors;

--- a/ui/src/lib/yaml-to-graph.ts
+++ b/ui/src/lib/yaml-to-graph.ts
@@ -6,6 +6,8 @@ export interface WorkflowNode {
   label: string;
   type: string;
   status?: string;
+  patternGroup?: string;
+  patternType?: string;
 }
 
 export interface WorkflowEdge {
@@ -21,7 +23,7 @@ export interface GraphLayout {
 
 interface ParsedWorkflow {
   name?: string;
-  nodes?: Record<string, { agent: string; depends_on?: string[] }>;
+  nodes?: Record<string, { agent: string; depends_on?: string[]; config?: Record<string, unknown> }>;
 }
 
 const elk = new ELK();
@@ -34,7 +36,14 @@ export function parseWorkflowYaml(yamlContent: string): { nodes: WorkflowNode[];
     const agent = spec.agent ?? '';
     const prefix = agent.split('://')[0] ?? 'local';
     const type = prefix === 'cao' ? 'cao' : prefix;
-    return { id, label: id, type };
+    const config = spec.config;
+    return {
+      id,
+      label: id,
+      type,
+      patternGroup: config?._pattern_group as string | undefined,
+      patternType: config?._pattern_type as string | undefined,
+    };
   });
 
   const edges: WorkflowEdge[] = [];


### PR DESCRIPTION
## Summary

- Add 9 pattern macro-nodes (Critic, Debate, Best-of-N, Reflexion, Scatter, FSM, Constitutional, Chain-of-Verification, Plan-Execute) that expand into sub-DAGs at YAML parse time
- PatternExpander integrates with the workflow loader — patterns expand before DAG construction
- UI: 9 pattern types in node palette, collapsible pattern groups in DAG view, pattern-specific config panel

## Changes

**Backend (Python):**
- `src/binex/patterns/` — new package: models (PatternSpec, StepConfig), 9 templates, expander
- `src/binex/models/workflow.py` — add `pattern` field to NodeSpec
- `src/binex/workflow_spec/loader.py` — wire `expand_patterns()` before back-edge validation
- `examples/patterns/` — critic.yaml, debate.yaml example workflows

**Frontend (TypeScript):**
- `NodePalette.tsx` — 9 pattern entries with pink color scheme
- `PatternGroup.tsx` — collapsible dashed-border group container
- `PatternConfig.tsx` — pattern-specific settings panel
- `CustomNode.tsx` — pattern badge in DAG view
- `yaml-to-graph.ts` — detect pattern group metadata
- `design-tokens.ts` — pattern color tokens

**Tests:**
- 546 new test lines across 3 files (models, expander, integration)
- All 2498 existing tests pass
- ruff clean, mypy clean (0 errors), TypeScript clean

## Test plan

- [x] `pytest tests/unit/test_pattern_models.py` — 6 tests pass
- [x] `pytest tests/unit/test_pattern_expander.py` — 57 tests pass (all 9 templates)
- [x] `pytest tests/unit/test_pattern_integration.py` — 3 tests pass (YAML→expand→DAG)
- [x] Full suite: 2498 passed
- [x] `ruff check src/binex/patterns/` — all checks passed
- [x] `mypy src/binex/patterns/` — 0 errors
- [x] `npx tsc --noEmit` — TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)