### PR TITLE
fix(landing): correct docs URL, hero GitHub link, add docs to navbar

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -897,7 +897,7 @@ h1.hero-h .accent::after {
         <a class="btn" href="#demo">
           <span>▶ watch the demo</span>
         </a>
-        <a class="btn" href="https://github.com/" target="_blank" rel="noopener">
+        <a class="btn" href="https://github.com/Alexli18/binex" target="_blank" rel="noopener">
           <span>★ github</span>
           <span class="kbd">54 stars</span>
         </a>

--- a/website/index.html
+++ b/website/index.html
@@ -872,6 +872,7 @@ h1.hero-h .accent::after {
       <a href="#models">models</a>
       <a href="#compare">vs cloud</a>
       <a href="#community">community</a>
+      <a href="https://alexli18.github.io/binex/docs/" target="_blank" rel="noopener">docs</a>
       <a class="nav-cta" href="#install">pip install binex</a>
     </div>
   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -890,7 +890,7 @@ h1.hero-h .accent::after {
         Binex is an open-source visual runtime for AI agent pipelines. Drag nodes. Pick any model. Run locally. Replay any step. Your data, your graph, your keys — never leaves your machine.
       </p>
       <div class="hero-actions">
-        <a class="btn btn-primary" href="https://alexli18.github.io/binex/quickstart/" target="_blank" rel="noopener">
+        <a class="btn btn-primary" href="https://alexli18.github.io/binex/docs/quickstart/" target="_blank" rel="noopener">
           <span>$ pip install binex</span>
           <span class="kbd">docs</span>
         </a>
@@ -1530,7 +1530,7 @@ $ binex replay run/0421-a7f2 writer \
         <div style="display:flex; gap:12px; flex-wrap:wrap;">
           <a class="btn" href="https://github.com/Alexli18/binex" target="_blank" rel="noopener">★ star on github</a>
           <a class="btn" href="https://github.com/Alexli18/binex/discussions" target="_blank" rel="noopener">↘ discussions</a>
-          <a class="btn" href="https://alexli18.github.io/binex" target="_blank" rel="noopener">→ read the docs</a>
+          <a class="btn" href="https://alexli18.github.io/binex/docs/" target="_blank" rel="noopener">→ read the docs</a>
         </div>
       </div>
     </div>
@@ -1560,10 +1560,10 @@ $ binex replay run/0421-a7f2 writer \
       <div>
         <h5>docs</h5>
         <ul>
-          <li><a href="https://alexli18.github.io/binex/quickstart/" target="_blank" rel="noopener">quickstart</a></li>
-          <li><a href="https://alexli18.github.io/binex/concepts/workflows/" target="_blank" rel="noopener">yaml reference</a></li>
-          <li><a href="https://alexli18.github.io/binex/concepts/agents/" target="_blank" rel="noopener">node types</a></li>
-          <li><a href="https://alexli18.github.io/binex/features/tools-mcp/" target="_blank" rel="noopener">MCP guide</a></li>
+          <li><a href="https://alexli18.github.io/binex/docs/quickstart/" target="_blank" rel="noopener">quickstart</a></li>
+          <li><a href="https://alexli18.github.io/binex/docs/concepts/workflows/" target="_blank" rel="noopener">yaml reference</a></li>
+          <li><a href="https://alexli18.github.io/binex/docs/concepts/agents/" target="_blank" rel="noopener">node types</a></li>
+          <li><a href="https://alexli18.github.io/binex/docs/features/tools-mcp/" target="_blank" rel="noopener">MCP guide</a></li>
           <li><a href="https://github.com/Alexli18/binex/tree/master/docs" target="_blank" rel="noopener">plugins</a></li>
         </ul>
       </div>
@@ -1574,14 +1574,14 @@ $ binex replay run/0421-a7f2 writer \
           <li><a href="https://github.com/Alexli18/binex/discussions" target="_blank" rel="noopener">discussions</a></li>
           <li><a href="https://github.com/Alexli18/binex/blob/master/CHANGELOG.md" target="_blank" rel="noopener">changelog</a></li>
           <li><a href="https://github.com/Alexli18/binex/issues" target="_blank" rel="noopener">roadmap</a></li>
-          <li><a href="https://alexli18.github.io/binex/contributing/" target="_blank" rel="noopener">contribute</a></li>
+          <li><a href="https://alexli18.github.io/binex/docs/contributing/development/" target="_blank" rel="noopener">contribute</a></li>
         </ul>
       </div>
       <div>
         <h5>legal</h5>
         <ul>
           <li><a href="https://github.com/Alexli18/binex/blob/master/LICENSE" target="_blank" rel="noopener">MIT license</a></li>
-          <li><a href="https://alexli18.github.io/binex/features/security/" target="_blank" rel="noopener">security</a></li>
+          <li><a href="https://alexli18.github.io/binex/docs/features/security/" target="_blank" rel="noopener">security</a></li>
           <li><a href="https://github.com/Alexli18/binex" target="_blank" rel="noopener">acceptable use</a></li>
           <li><a href="https://github.com/Alexli18/binex" target="_blank" rel="noopener">imprint</a></li>
         </ul>


### PR DESCRIPTION
## Summary
- Correct docs base URL from `/quickstart/` to `/docs/quickstart/` across all 8 links
- Fix hero GitHub button pointing to `github.com/` root → `github.com/Alexli18/binex`
- Add "docs" link to navbar → `https://alexli18.github.io/binex/docs/`

Three commits that landed on `design/amber-redesign` after PR #45 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)