### PR TITLE
feat(resume): binex resume <run-id> — continue a failed run from the point of failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **`binex resume <run-id>`** — continue a failed or interrupted run from where it stopped. Completed nodes are cached (artifacts reused, budget not re-spent); failed, timed-out, pending, and orphaned-running nodes are re-executed. The resumed run is a new immutable child linked via `resumed_from`. Partitioning is by node status (not a topological prefix), so parallel-branch failures resume correctly. Per-node drift detection re-runs only nodes whose definition changed; a topology change is refused unless `--force`. `cancelled`/`stopped` runs resume with a warning; `running` runs are refused without `--force` to avoid double execution. `--from <node>` forces re-execution from a node and its descendants. Budget is cumulative across the resume chain. (#54)
+
 ## v0.7.5
 
 Amber redesign, pattern step editor, and repository polish.

--- a/docs/cli/resume.md
+++ b/docs/cli/resume.md
@@ -1,0 +1,106 @@
+# binex resume
+
+## Synopsis
+
+```
+binex resume RUN_ID [--from NODE] [--force] [OPTIONS]
+```
+
+## Description
+
+Continue a failed or interrupted run from the point where it stopped. Unlike
+[`replay`](replay.md) — which re-executes from a step you choose — `resume`
+figures out what to redo automatically: nodes that **completed** are cached
+(their artifacts are reused, so the budget is not re-spent), while **failed**,
+**timed-out**, never-started, and orphaned-`running` nodes are re-executed.
+
+The resumed run is stored as a new run with its own `run_id`, linked to the
+parent via `resumed_from` metadata. This keeps runs immutable so `diff`,
+`bisect`, and lineage continue to work. `resumed_from` is distinct from
+`forked_from` (used by `replay`): a resume is a **continuation of the same
+intent**, not a new experiment.
+
+The workflow definition is loaded from the parent run's recorded path.
+
+Exits `0` on success, `1` on failure.
+
+## Options
+
+| Option | Type | Description |
+|---|---|---|
+| `RUN_ID` | `string` | The run to resume |
+| `--from` | `string` | Force re-execution from this node and everything downstream, overriding the status-based partition |
+| `--force` | flag | Override topology-drift and `running`-status refusals |
+| `--json-output` / `--json` | flag | Output as JSON |
+
+## Basic Example
+
+```bash
+# A run failed at node 9 of 10 — continue where it stopped
+binex resume run_a1b2c3d4
+```
+
+**Output:**
+
+```
+Resume Run ID: run_e5f6a7b8c9d0
+Resumed from: run_a1b2c3d4
+Workflow: report-pipeline
+Status: completed
+Nodes: 10/10 completed (8 cached, 2 re-run)
+Cost (cumulative): $0.0431
+```
+
+## How nodes are partitioned
+
+For a run with a parallel DAG, the set of completed nodes is not a simple
+prefix — one branch may have finished while another failed. Resume partitions
+by **actual node status**:
+
+- **Cached** — nodes that `COMPLETED` in the parent, whose definition is
+  unchanged, and whose entire upstream is also cached.
+- **Re-run** — `FAILED`, `TIMED_OUT`, never-started (pending), and
+  orphaned-`RUNNING` nodes (a node left `running` with no result has no
+  artifact to reuse).
+
+## Which runs can be resumed
+
+| Parent status | Behaviour |
+|---|---|
+| `failed` / `timed_out` | Resumes freely |
+| `cancelled` / `stopped` | Resumes, but warns — the stop was deliberate; the explicit `resume` command is your intent |
+| `running` | **Refused** by default — the run may still be live in another process (two orchestrators writing the same DB). Use `--force` only when the process is confirmed dead |
+| `completed` | Error — nothing to resume |
+
+## Workflow drift
+
+If you edit the workflow between the failed run and the resume, `resume`
+detects it **per node**:
+
+- A completed node whose definition (agent, prompt, inputs, config, tools,
+  dependencies) is unchanged → its cached artifact is reused.
+- A completed node whose definition changed → it and everything downstream are
+  re-run, so a stale artifact is never fed into a changed node.
+- A **topology change** (a depended-on node removed) → resume is **refused**
+  unless you pass `--force`.
+
+## `--from` — force re-execution
+
+```bash
+# Redo node "enrich" and every node that depends on it, even if they completed
+binex resume run_a1b2c3d4 --from enrich
+```
+
+This is the manual override: the node and all its descendants move from cached
+to re-run.
+
+## Budget
+
+Budget is cumulative across a resume chain: the child run starts from the
+parent's accumulated cost, so a workflow budget cap cannot be evaded by
+resuming.
+
+## See also
+
+- [`replay`](replay.md) — re-execute from a chosen step, or swap agents
+- [`debug`](debug.md) — inspect why a run failed before resuming

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
     - debug: cli/debug.md
     - trace: cli/trace.md
     - replay: cli/replay.md
+    - resume: cli/resume.md
     - diff: cli/diff.md
     - artifacts: cli/artifacts.md
     - dev: cli/dev.md

--- a/src/binex/cli/main.py
+++ b/src/binex/cli/main.py
@@ -24,6 +24,7 @@ from binex.cli.init_cmd import init_cmd
 from binex.cli.list_cmd import list_cmd
 from binex.cli.plugins_cmd import plugins_group
 from binex.cli.replay import replay_cmd
+from binex.cli.resume import resume_cmd
 from binex.cli.run import cancel_cmd, run_cmd
 from binex.cli.scaffold import scaffold_group
 from binex.cli.scheduler import scheduler_group
@@ -64,6 +65,7 @@ cli.add_command(cancel_cmd, "cancel")
 cli.add_command(trace_cmd, "trace")
 cli.add_command(artifacts_cmd, "artifacts")
 cli.add_command(replay_cmd, "replay")
+cli.add_command(resume_cmd, "resume")
 cli.add_command(debug_cmd, "debug")
 cli.add_command(diff_cmd, "diff")
 cli.add_command(hello_cmd, "hello")

--- a/src/binex/cli/resume.py
+++ b/src/binex/cli/resume.py
@@ -1,0 +1,100 @@
+"""CLI `binex resume` command — continue a failed run from the point of failure."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+
+import click
+
+from binex.cli import get_stores
+from binex.runtime.resume import ResumeError, ResumeResult
+
+
+@click.command("resume", epilog="""\b
+Examples:
+  binex resume <run_id>                 Continue a failed run where it stopped
+  binex resume <run_id> --from step3    Force re-run from step3 onward
+  binex resume <run_id> --force         Override drift / running-status refusal
+""")
+@click.argument("run_id")
+@click.option(
+    "--from", "from_node", default=None,
+    help="Force re-execution from this node and everything downstream",
+)
+@click.option(
+    "--force", is_flag=True,
+    help="Override topology-drift and running-status refusals",
+)
+@click.option("--json-output", "--json", "json_out", is_flag=True, help="Output as JSON")
+def resume_cmd(
+    run_id: str, from_node: str | None, force: bool, json_out: bool,
+) -> None:
+    """Resume a failed or interrupted run into a new child run."""
+    try:
+        result = asyncio.run(_run_resume(run_id, from_node, force))
+    except ResumeError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    for warning in result.warnings:
+        click.echo(f"⚠ {warning}", err=True)
+
+    summary = result.summary
+    if json_out:
+        data = summary.model_dump()
+        data["resumed_nodes"] = result.resumed_nodes
+        data["cached_nodes"] = result.cached_nodes
+        click.echo(json.dumps(data, default=str, indent=2))
+    else:
+        click.echo(f"Resume Run ID: {summary.run_id}")
+        click.echo(f"Resumed from: {summary.resumed_from}")
+        click.echo(f"Workflow: {summary.workflow_name}")
+        click.echo(f"Status: {summary.status}")
+        click.echo(
+            f"Nodes: {summary.completed_nodes}/{summary.total_nodes} completed "
+            f"({result.cached_nodes} cached, {result.resumed_nodes} re-run)"
+        )
+        if summary.failed_nodes:
+            click.echo(f"Failed: {summary.failed_nodes}")
+        if summary.total_cost > 0:
+            click.echo(f"Cost (cumulative): ${summary.total_cost:.4f}")
+
+    sys.exit(0 if summary.status == "completed" else 1)
+
+
+async def _run_resume(
+    run_id: str, from_node: str | None, force: bool,
+) -> ResumeResult:
+    from binex.cli.adapter_registry import register_workflow_adapters
+    from binex.plugins import PluginRegistry
+    from binex.runtime.resume import ResumeEngine
+    from binex.workflow_spec.loader import load_workflow
+
+    execution_store, artifact_store = get_stores()
+    try:
+        parent = await execution_store.get_run(run_id)
+        if parent is None:
+            raise ResumeError(f"Run '{run_id}' not found")
+        if not parent.workflow_path:
+            raise ResumeError(
+                f"Run '{run_id}' has no recorded workflow_path; cannot resume."
+            )
+
+        spec = load_workflow(parent.workflow_path)
+
+        engine = ResumeEngine(
+            execution_store=execution_store,
+            artifact_store=artifact_store,
+        )
+
+        plugin_registry = PluginRegistry()
+        plugin_registry.discover()
+        register_workflow_adapters(
+            engine.dispatcher, spec, plugin_registry=plugin_registry,
+        )
+
+        return await engine.resume(run_id, from_node=from_node, force=force)
+    finally:
+        await execution_store.close()

--- a/src/binex/graph/dag.py
+++ b/src/binex/graph/dag.py
@@ -51,6 +51,18 @@ class DAG:
     def dependents(self, node_id: str) -> set[str]:
         return self._forward.get(node_id, set())
 
+    def descendants(self, node_id: str) -> set[str]:
+        """Return all nodes transitively reachable via forward edges (exclusive)."""
+        result: set[str] = set()
+        queue = deque(self._forward.get(node_id, set()))
+        while queue:
+            current = queue.popleft()
+            if current in result:
+                continue
+            result.add(current)
+            queue.extend(self._forward.get(current, set()))
+        return result
+
     def entry_nodes(self) -> list[str]:
         return sorted(nid for nid in self._nodes if not self._backward[nid])
 

--- a/src/binex/models/execution.py
+++ b/src/binex/models/execution.py
@@ -46,6 +46,7 @@ class RunSummary(BaseModel):
     skipped_nodes: int = 0
     forked_from: str | None = None
     forked_at_step: str | None = None
+    resumed_from: str | None = None
     workflow_hash: str | None = None
     total_cost: float = 0.0
 

--- a/src/binex/runtime/resume.py
+++ b/src/binex/runtime/resume.py
@@ -1,0 +1,338 @@
+"""Resume engine — continue a failed/interrupted run from the point of failure.
+
+Resume creates a new immutable child run linked to its parent via
+``RunSummary.resumed_from``. Nodes that completed in the parent (and whose
+definition is unchanged) are cached — their artifacts are reused so the budget
+is not re-spent. Failed, timed-out, never-started, and orphaned-running nodes
+are re-executed. See issue #54 for the full design.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import yaml  # type: ignore[import-untyped]
+
+from binex.graph.dag import DAG
+from binex.graph.scheduler import Scheduler
+from binex.models.artifact import Artifact
+from binex.models.execution import RunSummary
+from binex.models.task import TaskStatus
+from binex.models.workflow import NodeSpec, WorkflowSpec
+from binex.runtime.back_edge import evaluate_when
+from binex.runtime.budget import check_batch_budget, skip_all_remaining
+from binex.runtime.replay import ReplayEngine
+
+# Node statuses whose output can be reused (cached) on resume. Skipped nodes
+# leave no execution record, so they fall through to re-run and are re-evaluated
+# against their `when` condition in the resume loop.
+_CACHEABLE = {TaskStatus.COMPLETED}
+# Parent run statuses that require a warning before resuming (deliberate stop).
+_INTENTIONAL_STOP = {"cancelled", "stopped"}
+
+
+class ResumeError(Exception):
+    """Raised when a run cannot be resumed."""
+
+
+@dataclass
+class ResumeResult:
+    """Outcome of a resume: the child run summary plus any user-facing warnings."""
+
+    summary: RunSummary
+    resumed_nodes: int
+    cached_nodes: int
+    warnings: list[str] = field(default_factory=list)
+
+
+def _node_hash(node: NodeSpec) -> str:
+    """Stable hash of a node's definition, for per-node drift detection.
+
+    Includes the fields that determine a node's output: agent, prompt, inputs,
+    config, tools, and its dependency edges. A change to any of these
+    invalidates the cached artifact for that node.
+    """
+    payload = {
+        "agent": node.agent,
+        "system_prompt": node.system_prompt,
+        "inputs": node.inputs,
+        "config": node.config,
+        "tools": node.tools,
+        "depends_on": sorted(node.depends_on),
+    }
+    blob = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(blob.encode()).hexdigest()
+
+
+class ResumeEngine(ReplayEngine):
+    """Resumes a failed/interrupted run, reusing cached artifacts of done nodes."""
+
+    async def resume(
+        self,
+        run_id: str,
+        *,
+        from_node: str | None = None,
+        force: bool = False,
+    ) -> ResumeResult:
+        """Resume a run into a new child run.
+
+        Args:
+            run_id: The parent run to resume.
+            from_node: Force re-execution starting at this node and everything
+                downstream (overrides the status/drift-based partition).
+            force: Override topology-drift and running-status refusals.
+
+        Raises:
+            ResumeError: If the run cannot be resumed.
+        """
+        parent = await self.execution_store.get_run(run_id)
+        if parent is None:
+            raise ResumeError(f"Run '{run_id}' not found")
+
+        warnings = self._check_resumable(parent, force=force)
+
+        spec = self._load_parent_spec(parent)
+        dag = DAG.from_workflow(spec)
+        topo = dag.topological_order()
+
+        parent_records = await self.execution_store.list_records(run_id)
+        status_by_node = {r.task_id: r.status for r in parent_records}
+
+        self._check_topology_drift(spec, status_by_node, force=force)
+
+        cached = await self._compute_cached_set(
+            parent, spec, dag, topo, status_by_node, from_node,
+        )
+        re_run = set(spec.nodes) - cached
+        if not re_run:
+            raise ResumeError(
+                f"Run '{run_id}' has no failed or pending nodes to resume."
+            )
+
+        return await self._execute_resume(
+            parent, spec, dag, topo, cached, re_run, warnings,
+        )
+
+    # ------------------------------------------------------------------
+    # Guards
+    # ------------------------------------------------------------------
+
+    def _check_resumable(self, parent: RunSummary, *, force: bool) -> list[str]:
+        """Validate the parent status; return warnings (raises if unresumable)."""
+        status = parent.status
+        if status == "completed":
+            raise ResumeError(
+                f"Run '{parent.run_id}' already completed — nothing to resume."
+            )
+        if status == "running" and not force:
+            raise ResumeError(
+                f"Run '{parent.run_id}' is still marked 'running'; it may be "
+                "active in another process. Re-run with --force only if the "
+                "process is confirmed dead."
+            )
+        if status in _INTENTIONAL_STOP:
+            return [
+                f"Run '{parent.run_id}' was {status}; resuming on explicit request."
+            ]
+        return []
+
+    def _load_parent_spec(self, parent: RunSummary) -> WorkflowSpec:
+        """Load the workflow spec from the parent's recorded path."""
+        from binex.workflow_spec.loader import load_workflow
+
+        if not parent.workflow_path:
+            raise ResumeError(
+                f"Run '{parent.run_id}' has no recorded workflow_path; "
+                "cannot resume."
+            )
+        try:
+            return load_workflow(parent.workflow_path)
+        except FileNotFoundError as exc:
+            raise ResumeError(
+                f"Workflow file '{parent.workflow_path}' not found; "
+                "cannot resume."
+            ) from exc
+
+    def _check_topology_drift(
+        self,
+        spec: WorkflowSpec,
+        status_by_node: dict[str, TaskStatus],
+        *,
+        force: bool,
+    ) -> None:
+        """Refuse if nodes the parent executed no longer exist in the spec."""
+        removed = sorted(nid for nid in status_by_node if nid not in spec.nodes)
+        if removed and not force:
+            raise ResumeError(
+                "Workflow topology changed since the run "
+                f"(missing nodes: {', '.join(removed)}). "
+                "Re-run with --force to override."
+            )
+
+    # ------------------------------------------------------------------
+    # Partitioning
+    # ------------------------------------------------------------------
+
+    async def _compute_cached_set(
+        self,
+        parent: RunSummary,
+        spec: WorkflowSpec,
+        dag: DAG,
+        topo: list[str],
+        status_by_node: dict[str, TaskStatus],
+        from_node: str | None,
+    ) -> set[str]:
+        """Partition nodes into cached (reused) vs re-run, by status + drift."""
+        parent_hashes = await self._parent_node_hashes(parent)
+        cur_hashes = {nid: _node_hash(n) for nid, n in spec.nodes.items()}
+
+        cached: set[str] = set()
+        for nid in topo:  # topological order → upstream decided before downstream
+            if status_by_node.get(nid) not in _CACHEABLE:
+                continue
+            # Per-node drift: a changed definition must be re-run.
+            if (
+                parent_hashes is not None
+                and parent_hashes.get(nid) != cur_hashes.get(nid)
+            ):
+                continue
+            # A node can only be cached if its entire upstream is cached.
+            if not dag.dependencies(nid).issubset(cached):
+                continue
+            cached.add(nid)
+
+        # --from override: invalidate the node and everything downstream.
+        if from_node is not None:
+            if from_node not in spec.nodes:
+                raise ResumeError(f"Node '{from_node}' not found in workflow")
+            cached -= {from_node} | dag.descendants(from_node)
+
+        return cached
+
+    async def _parent_node_hashes(
+        self, parent: RunSummary,
+    ) -> dict[str, str] | None:
+        """Per-node hashes of the parent's workflow snapshot, or None if absent."""
+        if not parent.workflow_hash:
+            return None
+        snapshot = await self.execution_store.get_workflow_snapshot(
+            parent.workflow_hash,
+        )
+        if not snapshot or "content" not in snapshot:
+            return None
+        try:
+            data = yaml.safe_load(snapshot["content"])
+            parent_spec = WorkflowSpec(**data)
+        except Exception:
+            return None
+        return {nid: _node_hash(n) for nid, n in parent_spec.nodes.items()}
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    async def _execute_resume(
+        self,
+        parent: RunSummary,
+        spec: WorkflowSpec,
+        dag: DAG,
+        topo: list[str],
+        cached: set[str],
+        re_run: set[str],
+        warnings: list[str],
+    ) -> ResumeResult:
+        """Create the child run, replay cached steps, and run the rest."""
+        child_id = f"run_{uuid.uuid4().hex[:12]}"
+        trace_id = f"trace_{uuid.uuid4().hex[:12]}"
+
+        # Cumulative budget: parent.total_cost is already cumulative-to-parent.
+        prior_cost = parent.total_cost
+
+        workflow_yaml = yaml.dump(
+            spec.model_dump(exclude={"source_path"}), sort_keys=True,
+        )
+        workflow_hash = await self.execution_store.store_workflow_snapshot(
+            workflow_yaml, version=spec.version,
+        )
+
+        summary = RunSummary(
+            run_id=child_id,
+            workflow_name=spec.name,
+            workflow_path=spec.source_path or parent.workflow_path,
+            workflow_hash=workflow_hash,
+            status="running",
+            total_nodes=len(spec.nodes),
+            resumed_from=parent.run_id,
+        )
+        await self.execution_store.create_run(summary)
+
+        node_artifacts: dict[str, list[Artifact]] = {}
+        await self._cache_upstream_steps(
+            parent.run_id, child_id, trace_id, topo, cached, node_artifacts,
+        )
+
+        scheduler = Scheduler(dag)
+        for nid in cached:
+            scheduler.mark_completed(nid)
+
+        accumulated_cost = prior_cost
+        budget_exceeded = False
+        while not scheduler.is_complete() and not scheduler.is_blocked():
+            ready = [n for n in scheduler.ready_nodes() if n in re_run]
+            if not ready:
+                await asyncio.sleep(0.01)
+                continue
+
+            if check_batch_budget(spec, accumulated_cost) == "stop":
+                budget_exceeded = True
+                skip_all_remaining(scheduler, ready)
+                break
+
+            tasks = []
+            for nid in ready:
+                node_spec = spec.nodes[nid]
+                if node_spec.when and not evaluate_when(node_spec.when, node_artifacts):
+                    scheduler.mark_skipped(nid)
+                    continue
+                scheduler.mark_running(nid)
+                tasks.append(
+                    self._execute_node(
+                        spec, dag, scheduler, child_id, trace_id,
+                        nid, node_artifacts, {},
+                    )
+                )
+            if tasks:
+                await asyncio.gather(*tasks)
+
+            cost_summary = await self.execution_store.get_run_cost_summary(child_id)
+            accumulated_cost = prior_cost + cost_summary.total_cost
+
+        summary.completed_at = datetime.now(UTC)
+        summary.completed_nodes = len(scheduler.completed)
+        summary.failed_nodes = len(scheduler.failed)
+        summary.skipped_nodes = len(scheduler.skipped)
+        summary.total_cost = accumulated_cost
+        summary.status = self._final_status(budget_exceeded, scheduler)
+        await self.execution_store.update_run(summary)
+
+        return ResumeResult(
+            summary=summary,
+            resumed_nodes=len(re_run),
+            cached_nodes=len(cached),
+            warnings=warnings,
+        )
+
+    @staticmethod
+    def _final_status(budget_exceeded: bool, scheduler: Scheduler) -> str:
+        if budget_exceeded:
+            return "over_budget"
+        if scheduler.failed:
+            return "failed"
+        if scheduler.is_complete():
+            return "completed"
+        return "failed"

--- a/src/binex/stores/backends/sqlite.py
+++ b/src/binex/stores/backends/sqlite.py
@@ -51,7 +51,8 @@ class SqliteExecutionStore:
                 forked_from TEXT,
                 forked_at_step TEXT,
                 total_cost REAL DEFAULT 0.0,
-                workflow_path TEXT
+                workflow_path TEXT,
+                resumed_from TEXT
             );
             CREATE TABLE IF NOT EXISTS execution_records (
                 id TEXT PRIMARY KEY,
@@ -135,6 +136,12 @@ class SqliteExecutionStore:
             await self._db.commit()
         except Exception as exc:
             logger.debug("Migration already applied or failed: %s", exc)
+        # Migration: add resumed_from column to existing runs table
+        try:
+            await self._db.execute("ALTER TABLE runs ADD COLUMN resumed_from TEXT")
+            await self._db.commit()
+        except Exception as exc:
+            logger.debug("Migration already applied or failed: %s", exc)
         # Migration: add trace_events column to existing execution_records table
         try:
             await self._db.execute(
@@ -183,8 +190,8 @@ class SqliteExecutionStore:
             """INSERT INTO runs (run_id, workflow_name, status, started_at,
                completed_at, total_nodes, completed_nodes, failed_nodes,
                skipped_nodes, forked_from, forked_at_step, total_cost,
-               workflow_path, workflow_hash)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               workflow_path, workflow_hash, resumed_from)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 run_summary.run_id,
                 run_summary.workflow_name,
@@ -200,6 +207,7 @@ class SqliteExecutionStore:
                 run_summary.total_cost,
                 run_summary.workflow_path,
                 run_summary.workflow_hash,
+                run_summary.resumed_from,
             ),
         )
         await db.commit()
@@ -221,7 +229,7 @@ class SqliteExecutionStore:
             """UPDATE runs SET workflow_name=?, status=?, started_at=?,
                completed_at=?, total_nodes=?, completed_nodes=?, failed_nodes=?,
                skipped_nodes=?, forked_from=?, forked_at_step=?, total_cost=?,
-               workflow_path=?, workflow_hash=?
+               workflow_path=?, workflow_hash=?, resumed_from=?
                WHERE run_id=?""",
             (
                 run_summary.workflow_name,
@@ -237,6 +245,7 @@ class SqliteExecutionStore:
                 run_summary.total_cost,
                 run_summary.workflow_path,
                 run_summary.workflow_hash,
+                run_summary.resumed_from,
                 run_summary.run_id,
             ),
         )
@@ -246,7 +255,7 @@ class SqliteExecutionStore:
         "SELECT run_id, workflow_name, status, started_at, completed_at,"
         " total_nodes, completed_nodes, failed_nodes, skipped_nodes,"
         " forked_from, forked_at_step, total_cost, workflow_path,"
-        " workflow_hash FROM runs"
+        " workflow_hash, resumed_from FROM runs"
     )
 
     async def list_runs(
@@ -335,6 +344,7 @@ class SqliteExecutionStore:
             total_cost=float(row[11]) if row[11] is not None else 0.0,
             workflow_path=row[12] if row[12] is not None else None,
             workflow_hash=str(row[13]) if row[13] is not None else None,
+            resumed_from=row[14] if len(row) > 14 and row[14] is not None else None,
         )
 
     async def record_cost(self, cost_record: CostRecord) -> None:

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -1,0 +1,240 @@
+"""Tests for the resume engine — src/binex/runtime/resume.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from binex.adapters.local import LocalPythonAdapter
+from binex.models.artifact import Artifact, Lineage
+from binex.models.execution import ExecutionRecord, RunSummary
+from binex.models.task import TaskStatus
+from binex.runtime.dispatcher import Dispatcher
+from binex.runtime.resume import ResumeEngine, ResumeError
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+
+@pytest.fixture
+def exec_store() -> InMemoryExecutionStore:
+    return InMemoryExecutionStore()
+
+
+@pytest.fixture
+def art_store() -> InMemoryArtifactStore:
+    return InMemoryArtifactStore()
+
+
+def _make_dispatcher() -> Dispatcher:
+    async def _handler(task, inputs):
+        content = {a.id: a.content for a in inputs} if inputs else {"msg": "seed"}
+        return [
+            Artifact(
+                id=f"art_{task.node_id}_{task.run_id}",
+                run_id=task.run_id,
+                type="result",
+                content=content,
+                lineage=Lineage(
+                    produced_by=task.node_id,
+                    derived_from=[a.id for a in inputs],
+                ),
+            )
+        ]
+
+    dispatcher = Dispatcher()
+    dispatcher.register_adapter("local://echo", LocalPythonAdapter(handler=_handler))
+    return dispatcher
+
+
+def _diamond_workflow() -> dict:
+    """Diamond DAG: a -> {b, c} -> d."""
+    return {
+        "name": "diamond",
+        "description": "a fans out to b,c which fan in to d",
+        "nodes": {
+            "a": {"agent": "local://echo", "system_prompt": "start",
+                  "inputs": {}, "outputs": ["ra"]},
+            "b": {"agent": "local://echo", "system_prompt": "left",
+                  "inputs": {"x": "${a.ra}"}, "outputs": ["rb"],
+                  "depends_on": ["a"]},
+            "c": {"agent": "local://echo", "system_prompt": "right",
+                  "inputs": {"x": "${a.ra}"}, "outputs": ["rc"],
+                  "depends_on": ["a"]},
+            "d": {"agent": "local://echo", "system_prompt": "join",
+                  "inputs": {"x": "${b.rb}", "y": "${c.rc}"}, "outputs": ["rd"],
+                  "depends_on": ["b", "c"]},
+        },
+    }
+
+
+def _write_workflow(tmp_path: Path, wf: dict) -> str:
+    path = tmp_path / "diamond.yaml"
+    path.write_text(yaml.dump(wf, sort_keys=True))
+    return str(path)
+
+
+async def _seed_partial_run(
+    exec_store: InMemoryExecutionStore,
+    art_store: InMemoryArtifactStore,
+    workflow_path: str,
+    *,
+    status: str = "failed",
+    total_cost: float = 0.0,
+    run_id: str = "run_parent",
+    workflow_hash: str | None = None,
+) -> RunSummary:
+    """Seed a diamond run where a,b completed, c failed, d never ran."""
+    summary = RunSummary(
+        run_id=run_id,
+        workflow_name="diamond",
+        workflow_path=workflow_path,
+        workflow_hash=workflow_hash,
+        status=status,
+        total_nodes=4,
+        completed_nodes=2,
+        failed_nodes=1,
+        total_cost=total_cost,
+    )
+    await exec_store.create_run(summary)
+
+    art_a = Artifact(id=f"art_a_{run_id}", run_id=run_id, type="ra",
+                     content={"v": "a"}, lineage=Lineage(produced_by="a"))
+    art_b = Artifact(id=f"art_b_{run_id}", run_id=run_id, type="rb",
+                     content={"v": "b"},
+                     lineage=Lineage(produced_by="b", derived_from=[art_a.id]))
+    for art in (art_a, art_b):
+        await art_store.store(art)
+
+    for node_id, refs_in, refs_out, st in [
+        ("a", [], [art_a.id], TaskStatus.COMPLETED),
+        ("b", [art_a.id], [art_b.id], TaskStatus.COMPLETED),
+        ("c", [art_a.id], [], TaskStatus.FAILED),
+    ]:
+        await exec_store.record(ExecutionRecord(
+            id=f"rec_{node_id}_{run_id}", run_id=run_id, task_id=node_id,
+            agent_id="local://echo", status=st,
+            input_artifact_refs=refs_in, output_artifact_refs=refs_out,
+            latency_ms=10, trace_id="trace_parent",
+            error="boom" if st == TaskStatus.FAILED else None,
+        ))
+
+    return summary
+
+
+def _engine(exec_store, art_store) -> ResumeEngine:
+    return ResumeEngine(
+        execution_store=exec_store, artifact_store=art_store,
+        dispatcher=_make_dispatcher(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_partitions_by_status(exec_store, art_store, tmp_path):
+    """Completed a,b are cached; failed c and pending d are re-run."""
+    wf_path = _write_workflow(tmp_path, _diamond_workflow())
+    await _seed_partial_run(exec_store, art_store, wf_path)
+
+    result = await _engine(exec_store, art_store).resume("run_parent")
+
+    assert result.summary.resumed_from == "run_parent"
+    assert result.summary.run_id != "run_parent"
+    assert result.cached_nodes == 2
+    assert result.resumed_nodes == 2
+    assert result.summary.status == "completed"
+
+    records = await exec_store.list_records(result.summary.run_id)
+    by_node = {r.task_id: r for r in records}
+    # a, b cached (copied); c, d freshly executed — all under the child run
+    assert set(by_node) == {"a", "b", "c", "d"}
+    assert by_node["a"].output_artifact_refs == ["art_a_run_parent"]
+    assert by_node["c"].status == TaskStatus.COMPLETED  # re-run succeeded
+
+
+@pytest.mark.asyncio
+async def test_resume_completed_run_rejected(exec_store, art_store, tmp_path):
+    wf_path = _write_workflow(tmp_path, _diamond_workflow())
+    await _seed_partial_run(exec_store, art_store, wf_path, status="completed")
+
+    with pytest.raises(ResumeError, match="already completed"):
+        await _engine(exec_store, art_store).resume("run_parent")
+
+
+@pytest.mark.asyncio
+async def test_resume_running_refused_without_force(exec_store, art_store, tmp_path):
+    wf_path = _write_workflow(tmp_path, _diamond_workflow())
+    await _seed_partial_run(exec_store, art_store, wf_path, status="running")
+
+    with pytest.raises(ResumeError, match="still marked 'running'"):
+        await _engine(exec_store, art_store).resume("run_parent")
+
+    # --force overrides
+    result = await _engine(exec_store, art_store).resume("run_parent", force=True)
+    assert result.summary.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_resume_cancelled_warns_but_proceeds(exec_store, art_store, tmp_path):
+    wf_path = _write_workflow(tmp_path, _diamond_workflow())
+    await _seed_partial_run(exec_store, art_store, wf_path, status="cancelled")
+
+    result = await _engine(exec_store, art_store).resume("run_parent")
+    assert any("cancelled" in w for w in result.warnings)
+    assert result.summary.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_resume_from_node_cascade(exec_store, art_store, tmp_path):
+    """--from b invalidates b and its descendant d, even though b completed."""
+    wf_path = _write_workflow(tmp_path, _diamond_workflow())
+    await _seed_partial_run(exec_store, art_store, wf_path)
+
+    result = await _engine(exec_store, art_store).resume("run_parent", from_node="b")
+
+    # Cached should now only be {a}; b, c, d all re-run.
+    assert result.cached_nodes == 1
+    assert result.resumed_nodes == 3
+
+
+@pytest.mark.asyncio
+async def test_resume_cumulative_budget(exec_store, art_store, tmp_path):
+    """Child run starts from the parent's accumulated cost."""
+    wf_path = _write_workflow(tmp_path, _diamond_workflow())
+    await _seed_partial_run(exec_store, art_store, wf_path, total_cost=5.0)
+
+    result = await _engine(exec_store, art_store).resume("run_parent")
+    # Echo adapter adds no cost, so cumulative == parent's prior cost.
+    assert result.summary.total_cost == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_resume_run_not_found(exec_store, art_store):
+    with pytest.raises(ResumeError, match="not found"):
+        await _engine(exec_store, art_store).resume("run_missing")
+
+
+@pytest.mark.asyncio
+async def test_resume_per_node_drift_reruns_changed_node(
+    exec_store, art_store, tmp_path,
+):
+    """A completed node whose definition changed is re-run, not cached."""
+    original = _diamond_workflow()
+    wf_path = _write_workflow(tmp_path, original)
+
+    # Store the ORIGINAL snapshot and hash it, as the orchestrator would.
+    snap = yaml.dump(original, sort_keys=True)
+    wf_hash = await exec_store.store_workflow_snapshot(snap, version=1)
+    await _seed_partial_run(
+        exec_store, art_store, wf_path, workflow_hash=wf_hash,
+    )
+
+    # Now change node b's prompt on disk (drift).
+    drifted = _diamond_workflow()
+    drifted["nodes"]["b"]["system_prompt"] = "CHANGED"
+    _write_workflow(tmp_path, drifted)
+
+    result = await _engine(exec_store, art_store).resume("run_parent")
+
+    # b changed -> only a is cacheable; b, c, d re-run.
+    assert result.cached_nodes == 1
+    assert result.resumed_nodes == 3


### PR DESCRIPTION
Closes #54.

## What

Adds `binex resume <run-id>` — continue a failed or interrupted run from where it stopped, reusing cached artifacts of completed nodes so the budget is not re-spent.

Unlike `replay` (re-execute from a step you choose), `resume` derives what to redo from actual node status. The resumed run is a new immutable child linked via a new `resumed_from` field — distinct from `forked_from` (replay/fork), so `diff`/`bisect`/lineage keep working and read the relationship as a continuation, not a new experiment.

## Design (locked in #54)

- **Partition by status, not topological prefix.** In a parallel DAG the completed set isn't a prefix — one branch may finish while another fails. Cached = `COMPLETED` nodes whose definition is unchanged and whose upstream is all cached; re-run = failed / timed-out / pending / orphaned-`running`.
- **Per-node drift.** Node definitions are hashed against the parent's stored workflow snapshot. Only changed nodes (and their descendants) are re-run; a stale artifact is never fed into a changed node. A **topology** change (a depended-on node removed) is refused unless `--force`.
- **Resume by parent status.** `failed`/`timed_out` resume freely; `cancelled`/`stopped` resume with a warning (the explicit command is the intent); `running` is refused without `--force` (double-execution guard); `completed` errors.
- **Cumulative budget** across the resume chain, so a cap can't be evaded by resuming.
- **`--from <node>`** forces re-execution from a node and its descendants.

## Changes

- `RunSummary.resumed_from` + SQLite migration (backward compatible; verified against a legacy DB).
- `ResumeEngine` (`runtime/resume.py`) reusing `ReplayEngine` helpers.
- `DAG.descendants()`; `when`-condition re-evaluation in the resume loop.
- CLI `binex resume` + registration.
- Docs (`docs/cli/resume.md` + nav) and CHANGELOG.

## Verification

- 8 new unit tests (real `Dispatcher` + stores, not mocks): status partition on a parallel-branch failure, completed-run rejection, `running`→`--force`, `cancelled` warning, `--from` cascade, per-node drift, cumulative budget, not-found.
- Full unit suite: **2509 passed**.
- `ruff` clean; `mypy` clean on all touched files.
- Live CLI smoke (`--help`, error path) and a real SQLite roundtrip + migration on a legacy DB.

## Out of scope (follow-ups)

- Async human-in-the-loop (approve via webhook hours later) — unblocked by this.
- Resume-chain flattening for diff/bisect back to the origin.
- `--refresh <node>` for stale source nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
