### PR TITLE
feat(concurrency): cap concurrent node execution, globally and per-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **Concurrency cap** — the orchestrator no longer dispatches unlimited nodes at once. A `concurrency` workflow field caps in-flight node execution, as a global scalar (`concurrency: 8`) or a per-provider mapping (`concurrency: {default: 8, openai: 5, ollama: 1}`). Providers are derived from the agent URI; a node holds a global slot plus its provider slot (acquired global-first, so no deadlock). Configurable via the `BINEX_MAX_CONCURRENCY` env var (default `8`); the workflow field takes precedence. Prevents wide fan-out (e.g. `scatter` with N=50) from tripping provider rate limits. (#55)
+
 ## v0.7.5
 
 Amber redesign, pattern step editor, and repository polish.

--- a/docs/workflows/format.md
+++ b/docs/workflows/format.md
@@ -14,6 +14,7 @@ Complete schema reference for Binex workflow files.
 | `budget` | `BudgetConfig` | no | Budget constraints for the run (see below) |
 | `webhook` | `WebhookConfig` | no | Webhook notification target (see below) |
 | `schedule` | `str` | no | Cron expression (5-field) for scheduled execution |
+| `concurrency` | `int` or `dict[str, int]` | no | Cap on concurrent node execution (see below) |
 | `mcp_servers` | `dict[str, McpServerConfig]` | no | MCP server configurations (see below) |
 
 ## Node — `NodeSpec`
@@ -163,6 +164,41 @@ With `--json`, the run output includes budget information:
   "remaining_budget": -0.23
 }
 ```
+
+## Concurrency
+
+By default the orchestrator would dispatch every ready node at once. A wide
+fan-out (e.g. a `scatter` pattern with 50 workers) then fires 50 simultaneous
+LLM calls and trips provider rate limits. `concurrency` caps how many nodes run
+at the same time.
+
+**Global cap (scalar):**
+
+```yaml
+name: wide-pipeline
+concurrency: 8        # at most 8 nodes in flight at once
+nodes:
+  ...
+```
+
+**Per-provider caps (mapping):** the `default` key is the global cap; every
+other key limits a single provider. A node holds a global slot *and* its
+provider slot, so a local Ollama (one GPU) and a hosted API can coexist:
+
+```yaml
+concurrency:
+  default: 8          # global cap (falls back to BINEX_MAX_CONCURRENCY, then 8)
+  openai: 5           # at most 5 concurrent openai calls
+  ollama: 1           # serialize the local model
+```
+
+The provider is derived from the agent URI: `llm://openai/gpt-4o` → `openai`,
+`llm://ollama/llama3` → `ollama`, and non-LLM agents fall back to their scheme
+(`local://` → `local`, `a2a://` → `a2a`).
+
+**Precedence:** the workflow `concurrency` field overrides the
+`BINEX_MAX_CONCURRENCY` environment variable, which overrides the default of
+`8`. All limits must be `>= 1`.
 
 ## Node Cost Hint — `NodeCostHint`
 

--- a/src/binex/models/workflow.py
+++ b/src/binex/models/workflow.py
@@ -127,6 +127,7 @@ class WorkflowSpec(BaseModel):
     webhook: WebhookConfig | None = None
     mcp_servers: dict[str, McpServerConfig] = Field(default_factory=dict)
     schedule: str | None = None
+    concurrency: int | dict[str, int] | None = None
     source_path: str | None = None
 
     @field_validator("version")
@@ -134,6 +135,18 @@ class WorkflowSpec(BaseModel):
     def version_must_be_positive(cls, v: int) -> int:
         if v < 1:
             raise ValueError("version must be >= 1")
+        return v
+
+    @field_validator("concurrency")
+    @classmethod
+    def concurrency_must_be_positive(
+        cls, v: int | dict[str, int] | None,
+    ) -> int | dict[str, int] | None:
+        if v is None:
+            return v
+        values = [v] if isinstance(v, int) else list(v.values())
+        if any(n < 1 for n in values):
+            raise ValueError("concurrency limits must be >= 1")
         return v
 
     @model_validator(mode="after")

--- a/src/binex/runtime/concurrency.py
+++ b/src/binex/runtime/concurrency.py
@@ -1,0 +1,83 @@
+"""Concurrency limiting for node execution.
+
+Wide fan-out (e.g. a scatter pattern with N=50 workers) would otherwise fire
+N simultaneous LLM calls and trip provider rate limits. ``ConcurrencyLimiter``
+caps in-flight node execution globally and, optionally, per provider — so a
+local Ollama (1 GPU) and a hosted API can have very different tolerances in the
+same workflow. See issue #55.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+
+def provider_of(agent: str) -> str:
+    """Extract the provider key from an agent URI.
+
+    ``llm://openai/gpt-4o`` -> ``openai``, ``ollama/llama3`` style models keep
+    their leading segment, and non-LLM agents fall back to their URI scheme
+    (``local://`` -> ``local``, ``a2a://`` -> ``a2a``).
+    """
+    if agent.startswith("llm://"):
+        model = agent.removeprefix("llm://")
+        return model.split("/", 1)[0] if "/" in model else model
+    if "://" in agent:
+        return agent.split("://", 1)[0]
+    return agent
+
+
+class ConcurrencyLimiter:
+    """Caps concurrent node execution globally and optionally per provider."""
+
+    def __init__(
+        self,
+        global_limit: int,
+        provider_limits: dict[str, int] | None = None,
+    ) -> None:
+        self.global_limit = global_limit
+        self.provider_limits = dict(provider_limits or {})
+        self._global = asyncio.Semaphore(global_limit)
+        self._providers = {
+            provider: asyncio.Semaphore(limit)
+            for provider, limit in self.provider_limits.items()
+        }
+
+    @classmethod
+    def from_spec(
+        cls,
+        concurrency: int | dict[str, int] | None,
+        default_limit: int,
+    ) -> ConcurrencyLimiter:
+        """Build from a ``WorkflowSpec.concurrency`` value.
+
+        A bare int is the global cap. A dict uses its ``default`` key as the
+        global cap (falling back to ``default_limit``) and every other key as a
+        per-provider cap.
+        """
+        if isinstance(concurrency, int):
+            return cls(concurrency)
+        if isinstance(concurrency, dict):
+            global_limit = concurrency.get("default", default_limit)
+            providers = {
+                k: v for k, v in concurrency.items() if k != "default"
+            }
+            return cls(global_limit, providers)
+        return cls(default_limit)
+
+    @asynccontextmanager
+    async def slot(self, agent: str) -> AsyncIterator[None]:
+        """Hold a global slot, plus the provider slot if one is configured.
+
+        Slots are always acquired global-then-provider, a fixed order, so nodes
+        cannot deadlock waiting on each other's semaphores.
+        """
+        provider_sem = self._providers.get(provider_of(agent))
+        async with self._global:
+            if provider_sem is None:
+                yield
+            else:
+                async with provider_sem:
+                    yield

--- a/src/binex/runtime/orchestrator.py
+++ b/src/binex/runtime/orchestrator.py
@@ -27,7 +27,9 @@ from binex.runtime.budget import (
     get_node_max_cost,
     skip_all_remaining,
 )
+from binex.runtime.concurrency import ConcurrencyLimiter
 from binex.runtime.dispatcher import Dispatcher, _backoff_delay
+from binex.settings import Settings
 from binex.stores.artifact_store import ArtifactStore
 from binex.stores.execution_store import ExecutionStore
 from binex.telemetry import get_tracer
@@ -57,6 +59,8 @@ class Orchestrator:
         self._stream_callback = stream_callback
         self._event_callback = event_callback
         self._interactive = interactive
+        # Default cap; replaced per-run once the workflow spec is known.
+        self._limiter = ConcurrencyLimiter(Settings().max_concurrency)
 
     async def _emit_event(self, event: dict[str, Any]) -> None:
         """Emit a lifecycle event if a callback is configured."""
@@ -93,6 +97,11 @@ class Orchestrator:
         scheduler = Scheduler(dag)
         run_id = run_id or f"run_{uuid.uuid4().hex[:12]}"
         trace_id = f"trace_{uuid.uuid4().hex[:12]}"
+
+        # Cap concurrent node execution: workflow field > env > default.
+        self._limiter = ConcurrencyLimiter.from_spec(
+            spec.concurrency, Settings().max_concurrency,
+        )
 
         # Store workflow snapshot
         workflow_yaml = yaml.dump(
@@ -402,10 +411,11 @@ class Orchestrator:
             "timestamp": datetime.now(UTC).isoformat(),
         })
 
-        succeeded, error_msg, output_artifacts = await self._retry_loop(
-            spec, run_id, node_id, task, input_artifacts, trace_id,
-            node_max, max_retries, retry_policy, node_artifacts,
-        )
+        async with self._limiter.slot(node_spec.agent):
+            succeeded, error_msg, output_artifacts = await self._retry_loop(
+                spec, run_id, node_id, task, input_artifacts, trace_id,
+                node_max, max_retries, retry_policy, node_artifacts,
+            )
 
         if succeeded:
             scheduler.mark_completed(node_id)

--- a/src/binex/settings.py
+++ b/src/binex/settings.py
@@ -20,6 +20,9 @@ class Settings:
         self.default_max_retries: int = int(
             os.environ.get("BINEX_DEFAULT_MAX_RETRIES", "1")
         )
+        self.max_concurrency: int = int(
+            os.environ.get("BINEX_MAX_CONCURRENCY", "8")
+        )
         self.default_backoff: Literal["fixed", "exponential"] = os.environ.get(  # type: ignore[assignment]
             "BINEX_DEFAULT_BACKOFF", "exponential"
         )

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -1,0 +1,151 @@
+"""Tests for concurrency limiting — src/binex/runtime/concurrency.py + orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from binex.adapters.local import LocalPythonAdapter
+from binex.models.artifact import Artifact, Lineage
+from binex.runtime.concurrency import ConcurrencyLimiter, provider_of
+from binex.runtime.orchestrator import Orchestrator
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+# --------------------------------------------------------------------------
+# provider_of
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("agent,expected", [
+    ("llm://openai/gpt-4o", "openai"),
+    ("llm://ollama/llama3", "ollama"),
+    ("llm://gpt-4o", "gpt-4o"),
+    ("local://echo", "local"),
+    ("a2a://host:8080/agent", "a2a"),
+    ("human://approve", "human"),
+])
+def test_provider_of(agent: str, expected: str):
+    assert provider_of(agent) == expected
+
+
+# --------------------------------------------------------------------------
+# ConcurrencyLimiter.from_spec
+# --------------------------------------------------------------------------
+
+def test_from_spec_int():
+    limiter = ConcurrencyLimiter.from_spec(5, default_limit=8)
+    assert limiter.global_limit == 5
+    assert limiter.provider_limits == {}
+
+
+def test_from_spec_dict_with_default():
+    limiter = ConcurrencyLimiter.from_spec(
+        {"default": 4, "openai": 2, "ollama": 1}, default_limit=8,
+    )
+    assert limiter.global_limit == 4
+    assert limiter.provider_limits == {"openai": 2, "ollama": 1}
+
+
+def test_from_spec_dict_without_default_falls_back():
+    limiter = ConcurrencyLimiter.from_spec({"openai": 2}, default_limit=8)
+    assert limiter.global_limit == 8
+    assert limiter.provider_limits == {"openai": 2}
+
+
+def test_from_spec_none_uses_default():
+    limiter = ConcurrencyLimiter.from_spec(None, default_limit=8)
+    assert limiter.global_limit == 8
+    assert limiter.provider_limits == {}
+
+
+# --------------------------------------------------------------------------
+# Actual in-flight limiting
+# --------------------------------------------------------------------------
+
+async def _measure_peak(limiter: ConcurrencyLimiter, agents: list[str]) -> dict:
+    """Run one slot() per agent concurrently; record peak concurrency overall
+    and per provider."""
+    state = {"active": 0, "peak": 0, "by_provider": {}, "prov_peak": {}}
+
+    async def work(agent: str) -> None:
+        provider = provider_of(agent)
+        async with limiter.slot(agent):
+            state["active"] += 1
+            state["peak"] = max(state["peak"], state["active"])
+            state["by_provider"][provider] = state["by_provider"].get(provider, 0) + 1
+            state["prov_peak"][provider] = max(
+                state["prov_peak"].get(provider, 0), state["by_provider"][provider],
+            )
+            await asyncio.sleep(0.02)
+            state["active"] -= 1
+            state["by_provider"][provider] -= 1
+
+    await asyncio.gather(*(work(a) for a in agents))
+    return state
+
+
+@pytest.mark.asyncio
+async def test_global_cap_limits_concurrency():
+    limiter = ConcurrencyLimiter(2)
+    state = await _measure_peak(limiter, ["llm://openai/gpt-4o"] * 10)
+    assert state["peak"] <= 2
+
+
+@pytest.mark.asyncio
+async def test_per_provider_cap_limits_that_provider():
+    limiter = ConcurrencyLimiter(10, {"ollama": 1})
+    agents = ["llm://ollama/llama3"] * 5 + ["llm://openai/gpt-4o"] * 5
+    state = await _measure_peak(limiter, agents)
+    # Ollama held to 1 at a time; global cap (10) lets the rest run freely.
+    assert state["prov_peak"]["ollama"] == 1
+    assert state["peak"] <= 10
+
+
+# --------------------------------------------------------------------------
+# Orchestrator integration
+# --------------------------------------------------------------------------
+
+def _tracking_dispatcher_workflow(concurrency: int) -> tuple[dict, dict]:
+    """Return (workflow_dict, shared_state) with 6 independent tracked nodes."""
+    workflow = {
+        "name": "fanout",
+        "concurrency": concurrency,
+        "nodes": {
+            f"n{i}": {
+                "agent": "local://track",
+                "system_prompt": "work",
+                "inputs": {},
+                "outputs": ["r"],
+            }
+            for i in range(6)
+        },
+    }
+    return workflow, {"active": 0, "peak": 0}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_respects_concurrency_field():
+    workflow, state = _tracking_dispatcher_workflow(concurrency=2)
+
+    async def handler(task, inputs):
+        state["active"] += 1
+        state["peak"] = max(state["peak"], state["active"])
+        await asyncio.sleep(0.02)
+        state["active"] -= 1
+        return [Artifact(
+            id=f"art_{task.node_id}_{task.run_id}", run_id=task.run_id,
+            type="r", content={"ok": True},
+            lineage=Lineage(produced_by=task.node_id),
+        )]
+
+    orch = Orchestrator(
+        artifact_store=InMemoryArtifactStore(),
+        execution_store=InMemoryExecutionStore(),
+    )
+    orch.dispatcher.register_adapter("local://track", LocalPythonAdapter(handler=handler))
+
+    summary = await orch.run_workflow(workflow)
+
+    assert summary.status == "completed"
+    assert summary.completed_nodes == 6
+    assert state["peak"] <= 2  # 6 ready nodes, but never more than 2 in flight


### PR DESCRIPTION
Closes #55.

## What

The orchestrator dispatched every ready node via `asyncio.gather` with **no cap**, so a wide fan-out (e.g. a `scatter` pattern with N=50 workers) fired 50 simultaneous LLM calls and immediately tripped provider rate limits. This adds a configurable cap on concurrent node execution — global, and optionally per provider.

## Design

- **`ConcurrencyLimiter`** (`runtime/concurrency.py`): a global `asyncio.Semaphore` plus optional per-provider semaphores. A node holds a **global slot, then its provider slot** — a fixed acquisition order, so nodes cannot deadlock waiting on each other.
- **Config** — `WorkflowSpec.concurrency` accepts:
  - a scalar: `concurrency: 8` (global cap only)
  - a mapping: `concurrency: {default: 8, openai: 5, ollama: 1}` — `default` is the global cap; every other key is a per-provider cap. This lets a local Ollama (one GPU) and a hosted API coexist in one workflow.
- **Provider** is derived from the agent URI: `llm://openai/gpt-4o` → `openai`, `llm://ollama/llama3` → `ollama`; non-LLM agents fall back to their scheme (`local://` → `local`, `a2a://` → `a2a`).
- **Precedence**: workflow field > `BINEX_MAX_CONCURRENCY` env var > default `8`. All limits validated `>= 1`.

## Changes

- `runtime/concurrency.py` — `ConcurrencyLimiter` + `provider_of`.
- `WorkflowSpec.concurrency` (`int | dict[str, int]`) with a `>= 1` validator.
- `Settings.max_concurrency` (`BINEX_MAX_CONCURRENCY`, default 8).
- Orchestrator resolves the limiter per run and wraps node dispatch/`_retry_loop` in a limiter slot.
- Docs (`docs/workflows/format.md` — Concurrency section) and CHANGELOG.

## Verification

- 13 new tests: provider parsing, `from_spec` resolution (int / dict / dict-without-default / none), **real in-flight limiting** (global cap holds peak ≤ N; per-provider cap serializes one provider while the global cap lets others run), and orchestrator integration (6 ready nodes, `concurrency: 2` → observed peak ≤ 2).
- Full unit suite: **2514 passed**.
- `ruff` clean; `mypy` clean on all touched files.

## Follow-ups (out of scope)

- Pairs naturally with #56 (event-driven scheduler): the cap makes wide DAGs safe; #56 makes them faster by removing the batch barrier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
