### PR TITLE
feat(scheduler): event-driven dispatch — remove batch barrier and busy-wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- **Event-driven scheduler** — the orchestrator now dispatches each node as soon as its dependencies complete, waking on the first completion (`asyncio.wait(FIRST_COMPLETED)`) instead of awaiting a whole batch. A slow node no longer blocks nodes whose dependencies already finished, and the busy-wait polling loop is gone. Combined with the concurrency cap, wide DAGs are both faster and safe. (#56)
 - **Concurrency cap** — the orchestrator no longer dispatches unlimited nodes at once. A `concurrency` workflow field caps in-flight node execution, as a global scalar (`concurrency: 8`) or a per-provider mapping (`concurrency: {default: 8, openai: 5, ollama: 1}`). Providers are derived from the agent URI; a node holds a global slot plus its provider slot (acquired global-first, so no deadlock). Configurable via the `BINEX_MAX_CONCURRENCY` env var (default `8`); the workflow field takes precedence. Prevents wide fan-out (e.g. `scatter` with N=50) from tripping provider rate limits. (#55)
 
 ## v0.7.5

--- a/docs/concepts/execution.md
+++ b/docs/concepts/execution.md
@@ -41,6 +41,10 @@ When the runtime dispatches a node to its [agent](agents.md), it creates an `Exe
 
 Execution records are persisted in `.binex/binex.db` (SQLite) via `SqliteExecutionStore`. Each record links to its [artifacts](artifacts.md) through `input_artifact_refs` and `output_artifact_refs`, and is grouped by `run_id` and `trace_id` for replay and debugging.
 
+## Scheduling
+
+The orchestrator is **event-driven**: a node is dispatched the moment all its dependencies complete, rather than in lockstep batches. When any node finishes, the newly-unblocked nodes on its branch start immediately — a slow node never holds up nodes on other branches whose dependencies are already satisfied. How many nodes run at once is bounded by the [concurrency cap](../workflows/format.md#concurrency); the rest queue until a slot frees.
+
 ## Example
 
 Query past executions from the CLI:

--- a/src/binex/runtime/orchestrator.py
+++ b/src/binex/runtime/orchestrator.py
@@ -135,35 +135,55 @@ class Orchestrator:
         node_artifacts_history: dict[str, list[list[Artifact]]] = {}
         accumulated_cost = 0.0
         budget_exceeded = False
+        budget_warned = False
 
-        while not scheduler.is_complete() and not scheduler.is_blocked():
-            ready = scheduler.ready_nodes()
-            if not ready:
-                await asyncio.sleep(0.01)
-                continue
+        # Event-driven loop: dispatch every ready node immediately (the
+        # concurrency limiter caps how many actually run), then wake on the
+        # first completion \u2014 no batch barrier, no polling. A slow node no
+        # longer blocks nodes whose dependencies already completed.
+        in_flight: set[asyncio.Task[None]] = set()
+        while True:
+            # Budget gates only the dispatch of *new* work; skip the check when
+            # nothing is ready so a floating-point overshoot on the final node
+            # doesn't flip a finished run to over_budget.
+            if not budget_exceeded and scheduler.ready_nodes():
+                budget_action = check_batch_budget(spec, accumulated_cost)
+                if budget_action == "stop":
+                    budget_exceeded = True
+                    skip_all_remaining(scheduler, scheduler.ready_nodes())
+                elif budget_action == "warn" and spec.budget and not budget_warned:
+                    budget_warned = True
+                    msg = (
+                        f"Budget exceeded: ${accumulated_cost:.2f} / "
+                        f"${spec.budget.max_cost:.2f} (policy: warn, continuing)"
+                    )
+                    logger.warning(msg)
+                    click.echo(f"\u26a0 {msg}", err=True)
 
-            # Budget check before scheduling next batch
-            budget_action = check_batch_budget(spec, accumulated_cost)
-            if budget_action == "stop":
-                budget_exceeded = True
-                skip_all_remaining(scheduler, ready)
+            # Dispatch the whole ready frontier. Re-check after each batch
+            # because when-skips synchronously unblock further nodes.
+            if not budget_exceeded:
+                while ready := scheduler.ready_nodes():
+                    coros = self._schedule_ready_nodes(
+                        spec, dag, scheduler, run_id, trace_id,
+                        ready, node_artifacts, accumulated_cost,
+                        node_artifacts_history,
+                    )
+                    if not coros:
+                        continue  # every ready node was skipped
+                    for coro in coros:
+                        in_flight.add(asyncio.ensure_future(coro))
+
+            if not in_flight:
                 break
-            if budget_action == "warn" and spec.budget:
-                msg = (
-                    f"Budget exceeded: ${accumulated_cost:.2f} / "
-                    f"${spec.budget.max_cost:.2f} (policy: warn, continuing)"
-                )
-                logger.warning(msg)
-                click.echo(f"\u26a0 {msg}", err=True)
 
-            tasks = self._schedule_ready_nodes(
-                spec, dag, scheduler, run_id, trace_id,
-                ready, node_artifacts, accumulated_cost,
-                node_artifacts_history,
+            done, in_flight = await asyncio.wait(
+                in_flight, return_when=asyncio.FIRST_COMPLETED,
             )
-
-            if tasks:
-                await asyncio.gather(*tasks)
+            for task in done:
+                exc = task.exception()
+                if exc is not None:
+                    logger.error("Node execution task crashed: %s", exc)
 
             # Update accumulated cost from store
             cost_summary = await self.execution_store.get_run_cost_summary(run_id)

--- a/tests/unit/test_event_scheduler.py
+++ b/tests/unit/test_event_scheduler.py
@@ -1,0 +1,97 @@
+"""Event-driven scheduling: a slow node must not block independent ready nodes.
+
+Under the old batch-barrier loop, all nodes in a batch were awaited together, so
+a fast node whose dependency finished early still waited for the slowest node in
+the batch. These tests pin the event-driven behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from binex.adapters.local import LocalPythonAdapter
+from binex.models.artifact import Artifact, Lineage
+from binex.runtime.orchestrator import Orchestrator
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+
+def _two_chain_workflow() -> dict:
+    """Two independent chains: fast1->fast2 and slow1->slow2."""
+    return {
+        "name": "two-chains",
+        "nodes": {
+            "fast1": {"agent": "local://work", "inputs": {}, "outputs": ["r"]},
+            "fast2": {"agent": "local://work", "inputs": {"x": "${fast1.r}"},
+                      "outputs": ["r"], "depends_on": ["fast1"]},
+            "slow1": {"agent": "local://work", "inputs": {}, "outputs": ["r"]},
+            "slow2": {"agent": "local://work", "inputs": {"x": "${slow1.r}"},
+                      "outputs": ["r"], "depends_on": ["slow1"]},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_fast_branch_not_blocked_by_slow_node():
+    completion_order: list[str] = []
+
+    async def handler(task, inputs):
+        # slow1 takes far longer than the whole fast chain.
+        await asyncio.sleep(0.15 if task.node_id == "slow1" else 0.01)
+        completion_order.append(task.node_id)
+        return [Artifact(
+            id=f"art_{task.node_id}_{task.run_id}", run_id=task.run_id,
+            type="r", content={"ok": True},
+            lineage=Lineage(produced_by=task.node_id),
+        )]
+
+    orch = Orchestrator(
+        artifact_store=InMemoryArtifactStore(),
+        execution_store=InMemoryExecutionStore(),
+    )
+    orch.dispatcher.register_adapter("local://work", LocalPythonAdapter(handler=handler))
+
+    summary = await orch.run_workflow(_two_chain_workflow())
+
+    assert summary.status == "completed"
+    assert summary.completed_nodes == 4
+    # The event-driven scheduler dispatches fast2 as soon as fast1 finishes,
+    # so the entire fast chain completes before the slow node — no batch barrier.
+    assert completion_order.index("fast2") < completion_order.index("slow1")
+
+
+@pytest.mark.asyncio
+async def test_all_ready_entry_nodes_run_together():
+    """Independent entry nodes are dispatched concurrently, not one batch at a time."""
+    active = 0
+    peak = 0
+
+    async def handler(task, inputs):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.02)
+        active -= 1
+        return [Artifact(
+            id=f"art_{task.node_id}_{task.run_id}", run_id=task.run_id,
+            type="r", content={}, lineage=Lineage(produced_by=task.node_id),
+        )]
+
+    workflow = {
+        "name": "fanout",
+        "nodes": {
+            f"n{i}": {"agent": "local://work", "inputs": {}, "outputs": ["r"]}
+            for i in range(4)
+        },
+    }
+    orch = Orchestrator(
+        artifact_store=InMemoryArtifactStore(),
+        execution_store=InMemoryExecutionStore(),
+    )
+    orch.dispatcher.register_adapter("local://work", LocalPythonAdapter(handler=handler))
+
+    summary = await orch.run_workflow(workflow)
+
+    assert summary.status == "completed"
+    assert peak >= 2  # ran concurrently (default cap is 8, well above 4)


### PR DESCRIPTION
Closes #56.

> **Stacked on #55** (`feat/concurrency-cap`). This PR's base is `feat/concurrency-cap`, not `master` — the event-driven loop relies on the concurrency limiter to bound how many nodes actually run. Merge #63 first; GitHub will retarget this to `master` afterward.

## What

The orchestrator's main loop had two problems:

1. **Batch barrier** — `await asyncio.gather(*tasks)` waited for the *entire* batch to finish before scheduling anything new. A slow node held up nodes whose dependencies had completed long ago.
2. **Busy-wait** — when nothing was ready the loop span on `await asyncio.sleep(0.01)`.

## How

The loop is now event-driven:

- Every ready node is dispatched immediately as an `asyncio.Task`; the [concurrency limiter](#55) caps how many actually execute, so the rest queue on the semaphore.
- The loop wakes on the **first** completion via `asyncio.wait(..., return_when=FIRST_COMPLETED)` — no barrier, no polling.
- As soon as any node finishes, the nodes it unblocks (dependency satisfied, or a back-edge chain reset) are dispatched without waiting for the rest of the frontier.
- `when`-skips are drained to a fixpoint each round (a skip synchronously unblocks its dependents).
- `asyncio.wait`, **not** `TaskGroup`: a `TaskGroup` cancels siblings when one child fails, which is wrong here — one node failing must not cancel the others.

## Note — budget gate

The budget check now runs only when there is a ready frontier to gate. Without this, the extra top-of-loop check (which the old barrier loop didn't have after the final batch) caught a floating-point overshoot — `0.10 × 3 = 0.30000000000000004 > 0.30` — and flipped a finished run to `over_budget`. Gating on "is there work to schedule" restores the original semantics.

## Verification

- New tests: a fast branch completes while a slow node on another branch is still running (`fast2` finishes before `slow1` — impossible under the old barrier); independent entry nodes run concurrently.
- Full unit suite: **2516 passed** (includes the existing budget, back-edge, pattern, and scatter suites, all green after the loop rewrite).
- `ruff` clean; `mypy` clean.
- Docs (`docs/concepts/execution.md` — Scheduling) and CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
