### PR TITLE
fix(sqlite): enable WAL mode and busy_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **SQLite WAL mode** — the store now opens the database with `PRAGMA journal_mode=WAL` (plus `busy_timeout=5000` and `synchronous=NORMAL`). The Web UI can read run data while the orchestrator is actively writing execution/cost records, instead of hitting `database is locked` during live runs. (#57)
+
 ## v0.7.5
 
 Amber redesign, pattern step editor, and repository polish.

--- a/src/binex/stores/backends/sqlite.py
+++ b/src/binex/stores/backends/sqlite.py
@@ -37,6 +37,13 @@ class SqliteExecutionStore:
         import os
         os.makedirs(os.path.dirname(self._db_path) or ".", exist_ok=True)
         self._db = await aiosqlite.connect(self._db_path)
+        # WAL lets the Web UI read run data while the orchestrator writes,
+        # instead of raising "database is locked" in rollback-journal mode.
+        # busy_timeout waits out brief write locks; synchronous=NORMAL is the
+        # safe, recommended pairing with WAL.
+        await self._db.execute("PRAGMA journal_mode=WAL")
+        await self._db.execute("PRAGMA busy_timeout=5000")
+        await self._db.execute("PRAGMA synchronous=NORMAL")
         await self._db.executescript("""
             CREATE TABLE IF NOT EXISTS runs (
                 run_id TEXT PRIMARY KEY,

--- a/tests/unit/test_sqlite_wal.py
+++ b/tests/unit/test_sqlite_wal.py
@@ -1,0 +1,61 @@
+"""WAL mode for the SQLite store — concurrent UI reads during orchestrator writes."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from binex.models.execution import RunSummary
+from binex.stores.backends.sqlite import SqliteExecutionStore
+
+
+def _run(run_id: str) -> RunSummary:
+    return RunSummary(
+        run_id=run_id, workflow_name="wf", status="running", total_nodes=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wal_pragmas_applied():
+    with tempfile.TemporaryDirectory() as d:
+        store = SqliteExecutionStore(os.path.join(d, "binex.db"))
+        db = await store._ensure_initialized()
+
+        mode = await (await db.execute("PRAGMA journal_mode")).fetchone()
+        timeout = await (await db.execute("PRAGMA busy_timeout")).fetchone()
+
+        assert mode is not None and mode[0].lower() == "wal"
+        assert timeout is not None and timeout[0] == 5000
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_read_during_write_no_lock():
+    """A second connection can read while the first writes — no 'database is locked'."""
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "binex.db")
+        writer = SqliteExecutionStore(path)
+        await writer.create_run(_run("seed"))  # initializes the file in WAL
+
+        reader = SqliteExecutionStore(path)
+        await reader._ensure_initialized()
+
+        async def write_many() -> None:
+            for i in range(30):
+                await writer.create_run(_run(f"run_{i}"))
+                await asyncio.sleep(0)
+
+        async def read_many() -> None:
+            for _ in range(30):
+                await reader.list_runs()
+                await asyncio.sleep(0)
+
+        # Should complete without raising sqlite "database is locked".
+        await asyncio.gather(write_many(), read_many())
+
+        assert len(await reader.list_runs()) >= 30
+        await writer.close()
+        await reader.close()


### PR DESCRIPTION
Closes #57.

Opens the SQLite database with:

```
PRAGMA journal_mode=WAL;
PRAGMA busy_timeout=5000;
PRAGMA synchronous=NORMAL;
```

WAL lets concurrent readers (the Web UI) run alongside a single writer (the orchestrator), which is exactly the access pattern that produced `database is locked` in rollback-journal mode during live runs. Low-risk, few lines.

## Verification
- 2 tests: WAL/busy_timeout pragmas applied on init; a second connection reads while the first writes 30 runs concurrently without locking.
- Full unit suite: 2503 passed. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)