### PR TITLE
feat(cost): binex cost simulate — estimate run cost on a different model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **`binex cost simulate`** — estimate what a run would cost on a different model from its stored token counts and litellm pricing, with **zero LLM calls**. `--node NODE --model M` swaps one node; `--all-nodes M` re-prices the whole pipeline. Results are shown as a range, not a point: the swapped node gets a ±10% tokenizer band, nodes downstream of the swap get a wider band (a different model may change output length, cascading into downstream inputs), and unpriced models keep the original cost and are flagged. `--json` for machine-readable output. (#70)
+
 ## v0.7.5
 
 Amber redesign, pattern step editor, and repository polish.

--- a/docs/cli/cost.md
+++ b/docs/cli/cost.md
@@ -98,6 +98,44 @@ $ binex cost show run_f7a1b2c3 --json
 
 The `budget` and `remaining_budget` fields only appear when the workflow defines a `budget` section.
 
+## Cost Simulate
+
+Estimates what a run **would have cost** on a different model, using the token
+counts already stored for the run and litellm's pricing table. It makes **zero
+LLM calls**.
+
+```bash
+# Swap one node to a cheaper model
+$ binex cost simulate run_f7a1b2c3 --node researcher --model claude-3-haiku-20240307
+
+Cost simulation for run run_f7a1b2c3 → claude-3-haiku-20240307
+
+  → researcher           $1.2000 → $0.0450–$0.0550
+  ~ summarizer           $0.8000 → $0.4800–$1.1200
+    planner              $0.5000 → $0.5000
+
+Total: $2.5000 → $1.0250–$1.6750 (estimated)
+```
+
+```bash
+# Re-price the entire pipeline
+$ binex cost simulate run_f7a1b2c3 --all-nodes gpt-4o-mini
+```
+
+Estimates are shown as a **range**, never a point:
+
+- The swapped node (`→`) gets a ±10% band for tokenizer differences.
+- Nodes **downstream** of the swap (`~`) get a wider band — a different model
+  may answer at a different length, and that output feeds the next node's input,
+  so the uncertainty cascades. Downstream detection uses the run's stored
+  workflow graph.
+- Other nodes are unchanged.
+- If the target model isn't in the pricing table, that node keeps its original
+  cost and is flagged.
+
+Add `--json` for machine-readable output. Use the order-of-magnitude answer
+("$4 or $0.30?"), not the exact cents.
+
 ## Cost History
 
 Displays cost events in chronological order:

--- a/src/binex/cli/cost.py
+++ b/src/binex/cli/cost.py
@@ -45,6 +45,32 @@ def cost_show_cmd(run_id: str, json_out: bool) -> None:
     asyncio.run(_cost_show(run_id, json_out))
 
 
+@cost_group.command("simulate", epilog="""\b
+Examples:
+  binex cost simulate <run_id> --node writer --model claude-3-haiku-20240307
+  binex cost simulate <run_id> --all-nodes gpt-4o-mini
+""")
+@click.argument("run_id")
+@click.option("--node", "node", default=None, help="Node to swap (with --model)")
+@click.option("--model", "model", default=None, help="Target model for --node")
+@click.option("--all-nodes", "all_nodes_model", default=None,
+              help="Re-price every node with this model")
+@click.option("--json-output", "--json", "json_out", is_flag=True, help="Output as JSON")
+def cost_simulate_cmd(
+    run_id: str, node: str | None, model: str | None,
+    all_nodes_model: str | None, json_out: bool,
+) -> None:
+    """Estimate what a run would cost on a different model (no LLM calls)."""
+    if all_nodes_model:
+        if node or model:
+            raise click.UsageError("--all-nodes cannot be combined with --node/--model")
+    elif node and model:
+        pass
+    else:
+        raise click.UsageError("provide either --all-nodes MODEL or --node NODE --model MODEL")
+    asyncio.run(_cost_simulate(run_id, node, model, all_nodes_model, json_out))
+
+
 async def _cost_show(run_id: str, json_out: bool) -> None:
     execution_store, _ = _get_stores()
     try:
@@ -63,6 +89,135 @@ async def _cost_show(run_id: str, json_out: bool) -> None:
             print_cost_text(run_id, cost_summary, cost_records)
     finally:
         await execution_store.close()
+
+
+def _descendants(dag: Any, node: str) -> set[str]:
+    """All nodes transitively reachable from ``node`` via forward edges."""
+    seen: set[str] = set()
+    stack = list(dag.dependents(node))
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(dag.dependents(current))
+    return seen
+
+
+async def _load_dag(execution_store: Any, run: Any) -> Any | None:
+    """Rebuild the run's DAG from its stored workflow snapshot (best-effort)."""
+    import yaml  # type: ignore[import-untyped]
+
+    from binex.graph.dag import DAG
+    from binex.models.workflow import WorkflowSpec
+
+    if not run.workflow_hash:
+        return None
+    snapshot = await execution_store.get_workflow_snapshot(run.workflow_hash)
+    if not snapshot or "content" not in snapshot:
+        return None
+    try:
+        spec = WorkflowSpec(**yaml.safe_load(snapshot["content"]))
+        return DAG.from_workflow(spec)
+    except Exception:
+        return None
+
+
+async def _cost_simulate(
+    run_id: str, node: str | None, model: str | None,
+    all_nodes_model: str | None, json_out: bool,
+) -> None:
+    from binex.cost_simulation import simulate
+
+    execution_store, _ = _get_stores()
+    try:
+        run = await execution_store.get_run(run_id)
+        if run is None:
+            click.echo(f"Error: Run '{run_id}' not found.", err=True)
+            sys.exit(1)
+
+        cost_records = await execution_store.list_costs(run_id)
+        all_node_ids = {rec.task_id for rec in cost_records}
+
+        if all_nodes_model:
+            target_model = all_nodes_model
+            swapped = set(all_node_ids)
+            downstream: set[str] = set()
+        else:
+            assert node is not None and model is not None
+            if node not in all_node_ids:
+                click.echo(
+                    f"Error: node '{node}' has no cost records in run '{run_id}'.",
+                    err=True,
+                )
+                sys.exit(1)
+            target_model = model
+            swapped = {node}
+            dag = await _load_dag(execution_store, run)
+            downstream = _descendants(dag, node) & all_node_ids if dag else set()
+
+        result = simulate(
+            cost_records, target_model=target_model,
+            swapped_nodes=swapped, downstream_nodes=downstream,
+        )
+
+        graph_used = bool(downstream) or bool(all_nodes_model)
+        if json_out:
+            _print_simulation_json(run_id, result)
+        else:
+            _print_simulation_text(run_id, result, dag_available=graph_used)
+    finally:
+        await execution_store.close()
+
+
+def _print_simulation_json(run_id: str, result: Any) -> None:
+    data = {
+        "run_id": run_id,
+        "target_model": result.target_model,
+        "original_total": round(result.orig_total, 6),
+        "estimated_total_low": round(result.est_low_total, 6),
+        "estimated_total_high": round(result.est_high_total, 6),
+        "disclaimer": result.disclaimer,
+        "nodes": [
+            {
+                "node": n.node_id,
+                "affected": n.affected,
+                "original_cost": round(n.orig_cost, 6),
+                "estimated_low": round(n.est_low, 6),
+                "estimated_high": round(n.est_high, 6),
+                "model_from": n.model_from,
+                "model_to": n.model_to,
+                "priced": n.priced,
+            }
+            for n in result.nodes
+        ],
+    }
+    click.echo(json.dumps(data, indent=2))
+
+
+def _print_simulation_text(run_id: str, result: Any, *, dag_available: bool) -> None:
+    click.echo(f"Cost simulation for run {run_id} → {result.target_model}")
+    click.echo("")
+    for n in result.nodes:
+        tag = {"swapped": "→", "downstream": "~", "unchanged": " "}[n.affected]
+        note = "" if n.priced else "  (unpriced model — kept original)"
+        rng = (
+            f"${n.est_low:.4f}"
+            if abs(n.est_high - n.est_low) < 1e-9
+            else f"${n.est_low:.4f}–${n.est_high:.4f}"
+        )
+        click.echo(f"  {tag} {n.node_id:<20} ${n.orig_cost:.4f} → {rng}{note}")
+    click.echo("")
+    click.echo(
+        f"Total: ${result.orig_total:.4f} → "
+        f"${result.est_low_total:.4f}–${result.est_high_total:.4f} (estimated)"
+    )
+    if not dag_available and any(n.affected == "swapped" for n in result.nodes):
+        click.echo(
+            "Note: workflow graph unavailable — downstream cost impact not estimated.",
+            err=True,
+        )
+    click.echo(f"\n{result.disclaimer}", err=True)
 
 
 def _print_cost_json(run_id: str, cost_summary: Any, cost_records: Any) -> None:

--- a/src/binex/cost_simulation.py
+++ b/src/binex/cost_simulation.py
@@ -1,0 +1,149 @@
+"""Cost simulation — estimate what a run would have cost on a different model.
+
+Uses the token counts already stored for a historical run plus litellm's pricing
+table, so it makes **zero** LLM calls. Because a different model may answer at a
+different length — and in a chain that output feeds the next node's input — the
+estimate is presented as a **range**, widened for nodes downstream of a swap,
+and always labelled as an estimate. See issue #70.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import litellm
+
+from binex.models.cost import CostRecord
+
+# Tokenizers differ between models, shifting counts by roughly ±10%.
+TOKENIZER_BAND = 0.10
+# A swapped node may change its output length, cascading into the input tokens
+# of everything downstream — so widen those estimates substantially.
+DOWNSTREAM_BAND = 0.40
+
+DISCLAIMER = (
+    "Estimated from historical token usage; not a quote. "
+    "Ranges widen downstream of a swap."
+)
+
+
+def price_tokens(model: str, prompt_tokens: int, completion_tokens: int) -> float | None:
+    """Cost of the given token counts on ``model``, or None if the model is unpriced."""
+    try:
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+        )
+        return float(prompt_cost + completion_cost)
+    except Exception:
+        return None
+
+
+@dataclass
+class NodeEstimate:
+    node_id: str
+    orig_cost: float
+    est_low: float
+    est_high: float
+    model_from: str | None
+    model_to: str | None
+    affected: str  # "swapped" | "downstream" | "unchanged"
+    priced: bool = True
+
+
+@dataclass
+class SimulationResult:
+    target_model: str
+    orig_total: float
+    est_low_total: float
+    est_high_total: float
+    nodes: list[NodeEstimate] = field(default_factory=list)
+    disclaimer: str = DISCLAIMER
+
+
+@dataclass
+class _NodeAgg:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    orig_cost: float = 0.0
+    model: str | None = None
+    has_tokens: bool = False
+
+
+def _aggregate_by_node(cost_records: list[CostRecord]) -> dict[str, _NodeAgg]:
+    """Sum token counts and cost per node (a node may have several records)."""
+    by_node: dict[str, _NodeAgg] = {}
+    for rec in cost_records:
+        agg = by_node.setdefault(rec.task_id, _NodeAgg())
+        agg.orig_cost += rec.cost
+        agg.model = rec.model or agg.model
+        if rec.prompt_tokens is not None or rec.completion_tokens is not None:
+            agg.prompt_tokens += rec.prompt_tokens or 0
+            agg.completion_tokens += rec.completion_tokens or 0
+            agg.has_tokens = True
+    return by_node
+
+
+def simulate(
+    cost_records: list[CostRecord],
+    *,
+    target_model: str,
+    swapped_nodes: set[str],
+    downstream_nodes: set[str],
+) -> SimulationResult:
+    """Estimate run cost after swapping ``swapped_nodes`` to ``target_model``.
+
+    ``downstream_nodes`` (descendants of a swap) keep their recorded cost but get
+    a wider uncertainty band, since their input tokens depend on the swapped
+    node's output length. All other nodes are unchanged.
+    """
+    by_node = _aggregate_by_node(cost_records)
+    nodes: list[NodeEstimate] = []
+    orig_total = est_low_total = est_high_total = 0.0
+
+    for node_id in sorted(by_node):
+        agg = by_node[node_id]
+        orig_total += agg.orig_cost
+
+        if node_id in swapped_nodes:
+            new_cost = (
+                price_tokens(target_model, agg.prompt_tokens, agg.completion_tokens)
+                if agg.has_tokens else None
+            )
+            if new_cost is None:
+                # Unpriced model or no token data: keep original, flag it.
+                est = NodeEstimate(
+                    node_id, agg.orig_cost, agg.orig_cost, agg.orig_cost,
+                    agg.model, target_model, "swapped", priced=False,
+                )
+            else:
+                est = NodeEstimate(
+                    node_id, agg.orig_cost,
+                    new_cost * (1 - TOKENIZER_BAND), new_cost * (1 + TOKENIZER_BAND),
+                    agg.model, target_model, "swapped",
+                )
+        elif node_id in downstream_nodes:
+            est = NodeEstimate(
+                node_id, agg.orig_cost,
+                agg.orig_cost * (1 - DOWNSTREAM_BAND),
+                agg.orig_cost * (1 + DOWNSTREAM_BAND),
+                agg.model, agg.model, "downstream",
+            )
+        else:
+            est = NodeEstimate(
+                node_id, agg.orig_cost, agg.orig_cost, agg.orig_cost,
+                agg.model, agg.model, "unchanged",
+            )
+
+        est_low_total += est.est_low
+        est_high_total += est.est_high
+        nodes.append(est)
+
+    return SimulationResult(
+        target_model=target_model,
+        orig_total=orig_total,
+        est_low_total=est_low_total,
+        est_high_total=est_high_total,
+        nodes=nodes,
+    )

--- a/tests/unit/test_cost_cli.py
+++ b/tests/unit/test_cost_cli.py
@@ -256,8 +256,9 @@ class TestRunCostOutput:
             total_cost=0.50,
         )
 
-        from binex.models.cost import BudgetConfig
         from unittest.mock import MagicMock
+
+        from binex.models.cost import BudgetConfig
         spec = MagicMock()
         spec.nodes = {"step1": MagicMock(depends_on=[])}
         spec.budget = BudgetConfig(max_cost=5.00, policy="warn")
@@ -287,8 +288,9 @@ class TestRunCostOutput:
             total_cost=12.00,
         )
 
-        from binex.models.cost import BudgetConfig
         from unittest.mock import MagicMock
+
+        from binex.models.cost import BudgetConfig
         spec = MagicMock()
         spec.nodes = {
             "a": MagicMock(depends_on=[]),
@@ -309,3 +311,63 @@ class TestRunCostOutput:
         assert "Budget exceeded" in result.output or "budget exceeded" in result.output.lower()
         assert "$12.00" in result.output
         assert "$10.00" in result.output
+
+
+# ── cost simulate ──────────────────────────────────────────────────────
+
+class TestCostSimulate:
+    """Tests for `binex cost simulate <run_id>`."""
+
+    def test_all_nodes_swap_cheaper_model(self, runner, store_with_costs):
+        from binex.cli.cost import cost_simulate_cmd
+        with patch(
+            "binex.cli.cost._get_stores",
+            return_value=(store_with_costs, InMemoryArtifactStore()),
+        ):
+            result = runner.invoke(
+                cost_simulate_cmd,
+                ["run_test123", "--all-nodes", "gpt-4o-mini"],
+            )
+        assert result.exit_code == 0
+        assert "gpt-4o-mini" in result.output
+        assert "planner" in result.output and "researcher" in result.output
+        assert "estimated" in result.output.lower()
+
+    def test_single_node_swap_json(self, runner, store_with_costs):
+        from binex.cli.cost import cost_simulate_cmd
+        with patch(
+            "binex.cli.cost._get_stores",
+            return_value=(store_with_costs, InMemoryArtifactStore()),
+        ):
+            result = runner.invoke(
+                cost_simulate_cmd,
+                ["run_test123", "--node", "planner", "--model", "gpt-4o-mini", "--json"],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["target_model"] == "gpt-4o-mini"
+        planner = next(n for n in data["nodes"] if n["node"] == "planner")
+        assert planner["affected"] == "swapped"
+        assert planner["estimated_low"] <= planner["estimated_high"]
+
+    def test_missing_args_errors(self, runner, store_with_costs):
+        from binex.cli.cost import cost_simulate_cmd
+        with patch(
+            "binex.cli.cost._get_stores",
+            return_value=(store_with_costs, InMemoryArtifactStore()),
+        ):
+            result = runner.invoke(cost_simulate_cmd, ["run_test123"])
+        assert result.exit_code != 0
+
+    def test_unknown_node_errors(self, runner, store_with_costs):
+        from binex.cli.cost import cost_simulate_cmd
+        with patch(
+            "binex.cli.cost._get_stores",
+            return_value=(store_with_costs, InMemoryArtifactStore()),
+        ):
+            result = runner.invoke(
+                cost_simulate_cmd,
+                ["run_test123", "--node", "ghost", "--model", "gpt-4o-mini"],
+            )
+        assert result.exit_code == 1
+        assert "no cost records" in result.output

--- a/tests/unit/test_cost_simulation.py
+++ b/tests/unit/test_cost_simulation.py
@@ -1,0 +1,111 @@
+"""Tests for cost simulation — src/binex/cost_simulation.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from binex.cost_simulation import (
+    DOWNSTREAM_BAND,
+    TOKENIZER_BAND,
+    price_tokens,
+    simulate,
+)
+from binex.models.cost import CostRecord
+
+
+def _rec(task_id: str, model: str, pt: int, ct: int, cost: float) -> CostRecord:
+    return CostRecord(
+        id=f"c_{task_id}", run_id="run1", task_id=task_id, cost=cost,
+        source="llm_tokens", model=model, prompt_tokens=pt, completion_tokens=ct,
+    )
+
+
+def test_price_tokens_known_model():
+    cost = price_tokens("gpt-4o", 1000, 500)
+    assert cost is not None and cost > 0
+
+
+def test_price_tokens_unknown_model_returns_none():
+    assert price_tokens("totally-made-up-model-xyz", 1000, 500) is None
+
+
+def test_swap_single_node_reprices_with_band():
+    records = [
+        _rec("a", "gpt-4o", 1000, 500, 0.0075),
+        _rec("b", "gpt-4o", 2000, 200, 0.007),
+    ]
+    result = simulate(
+        records, target_model="gpt-4o-mini",
+        swapped_nodes={"a"}, downstream_nodes=set(),
+    )
+    by = {n.node_id: n for n in result.nodes}
+
+    # 'a' repriced on the cheaper model, with a ±10% band around the estimate.
+    a = by["a"]
+    assert a.affected == "swapped"
+    assert a.model_to == "gpt-4o-mini"
+    assert a.est_low < a.est_high
+    mid = (a.est_low + a.est_high) / 2
+    assert a.est_low == pytest.approx(mid * (1 - TOKENIZER_BAND))
+    assert a.est_high == pytest.approx(mid * (1 + TOKENIZER_BAND))
+    assert a.est_high < a.orig_cost  # mini is cheaper than gpt-4o
+
+    # 'b' untouched.
+    assert by["b"].affected == "unchanged"
+    assert by["b"].est_low == by["b"].est_high == pytest.approx(0.007)
+
+
+def test_downstream_nodes_get_widened_band():
+    records = [
+        _rec("a", "gpt-4o", 1000, 500, 0.0075),
+        _rec("b", "gpt-4o", 2000, 200, 0.010),
+    ]
+    result = simulate(
+        records, target_model="gpt-4o-mini",
+        swapped_nodes={"a"}, downstream_nodes={"b"},
+    )
+    b = next(n for n in result.nodes if n.node_id == "b")
+    assert b.affected == "downstream"
+    assert b.est_low == pytest.approx(0.010 * (1 - DOWNSTREAM_BAND))
+    assert b.est_high == pytest.approx(0.010 * (1 + DOWNSTREAM_BAND))
+
+
+def test_all_nodes_swap():
+    records = [
+        _rec("a", "gpt-4o", 1000, 500, 0.0075),
+        _rec("b", "gpt-4o", 2000, 200, 0.010),
+    ]
+    result = simulate(
+        records, target_model="gpt-4o-mini",
+        swapped_nodes={"a", "b"}, downstream_nodes=set(),
+    )
+    assert all(n.affected == "swapped" for n in result.nodes)
+    # Total range brackets a cheaper estimate than the original.
+    assert result.est_high_total < result.orig_total
+    assert result.est_low_total < result.est_high_total
+
+
+def test_unpriced_target_keeps_original_and_flags():
+    records = [_rec("a", "gpt-4o", 1000, 500, 0.0075)]
+    result = simulate(
+        records, target_model="made-up-model",
+        swapped_nodes={"a"}, downstream_nodes=set(),
+    )
+    a = result.nodes[0]
+    assert a.priced is False
+    assert a.est_low == a.est_high == pytest.approx(0.0075)
+
+
+def test_multiple_records_per_node_aggregate():
+    records = [
+        _rec("a", "gpt-4o", 500, 250, 0.004),
+        _rec("a", "gpt-4o", 500, 250, 0.004),  # retry
+    ]
+    result = simulate(
+        records, target_model="gpt-4o", swapped_nodes={"a"}, downstream_nodes=set(),
+    )
+    # Aggregated 1000/500 tokens; repriced on the same model ≈ original 0.0075.
+    a = result.nodes[0]
+    assert a.orig_cost == pytest.approx(0.008)
+    mid = (a.est_low + a.est_high) / 2
+    assert mid == pytest.approx(0.0075, rel=0.05)


### PR DESCRIPTION
Closes #70.

## What
`binex cost simulate <run-id>` estimates what a historical run would have cost on a different model, using the token counts already stored for the run plus litellm's pricing table. **Zero LLM calls.**

- `--node NODE --model M` — swap one node.
- `--all-nodes M` — re-price the whole pipeline.
- `--json` for machine-readable output.

## Honest estimates (per the issue)
Estimates are a **range**, never a point:
- Swapped node: ±10% tokenizer band.
- Nodes **downstream** of a swap: wider ±40% band — a different model may answer at a different length, and that output feeds the next node's input, so the error cascades. Downstream detection uses the run's stored workflow snapshot.
- Unpriced target model → node keeps its original cost and is flagged.

## Verification
- 7 logic tests + 4 CLI tests (all-nodes, single-node JSON, arg validation, unknown node).
- Full unit suite: 2512 passed. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)