### PR TITLE
fix(security): SSRF protection for fetch_url / http_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security
+
+- **SSRF protection for `fetch_url` / `http_request` (#59)** — the HTTP tools now resolve a URL's host and reject private, loopback, link-local, reserved, multicast, and unspecified addresses (RFC 1918, `127.0.0.0/8`, `169.254.0.0/16` cloud metadata, `::1`, `fc00::/7`, `0.0.0.0`) before connecting. Redirects are followed manually and every hop is re-validated, so a public URL can't `302` into the metadata service; only `http`/`https` schemes are allowed. Opt out for local use with `BINEX_ALLOW_PRIVATE_URLS=1`. Matters on servers running `binex gateway` / `binex scheduler`.
+
 ### Features
 
 - **Node caching** — reuse a node's result when nothing that affects its output has changed, so editing a downstream prompt no longer forces re-running (and re-paying for) unchanged upstream nodes. The cache key is a content hash of the agent, resolved prompt, model parameters, tools, and input-artifact content; a hit is served at `$0` with a distinct `node:cache_hit` trace event pointing to the source run. Opt-in via per-node `cache: true` or run-level `binex run --cache`; `binex run --offline` runs only from cache (a miss fails the node — VCR-style iteration). New `binex clean cache [--older-than DAYS] [--dry-run]` clears the cache. (#68)

--- a/docs/features/security.md
+++ b/docs/features/security.md
@@ -15,6 +15,22 @@ Binex built-in tools run with the permissions of the orchestrator process. Two t
 - Output truncated to 10KB
 - No shell expansion (`|`, `&&`, `;`, backticks have no effect)
 
+### fetch_url / http_request — SSRF (patched, issue #59)
+
+**Before:** Both tools fetched any URL the model produced, with redirects
+enabled and no address filtering. On a server (Binex ships `binex gateway` and
+`binex scheduler`), an LLM-controlled HTTP client could reach cloud metadata
+endpoints (`169.254.169.254`), localhost admin panels, and internal services.
+
+**After:** Before connecting, the URL's host is resolved and rejected if it maps
+to a private, loopback, link-local, reserved, multicast, or unspecified address
+(RFC 1918, `127.0.0.0/8`, `169.254.0.0/16`, `::1`, `fc00::/7`, `0.0.0.0`).
+Redirects are followed manually and **every hop is re-validated**, so a public
+URL can't `302` into the metadata service. Only `http`/`https` schemes are
+allowed.
+
+**Opt-out:** set `BINEX_ALLOW_PRIVATE_URLS=1` for legitimate local requests.
+
 ### calculator — Arbitrary Code Execution (CRITICAL, patched)
 
 **Before:** Used raw `eval(expression)` — any agent could execute arbitrary Python code.

--- a/src/binex/tools/builtins.py
+++ b/src/binex/tools/builtins.py
@@ -121,17 +121,18 @@ def dice_roll(notation: str) -> str:
 
 @tool(description="Fetch contents of a URL via HTTP GET")
 async def fetch_url(url: str) -> str:
-    """Fetch URL contents."""
-    import httpx
+    """Fetch URL contents (public addresses only — see SSRF policy)."""
+    from binex.tools.ssrf import BlockedURLError, guarded_fetch
 
     try:
-        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-            resp = await client.get(url)
-            resp.raise_for_status()
-            text = resp.text
-            if len(text) > 50_000:
-                text = text[:50_000] + "\n...(truncated to 50KB)"
-            return text
+        resp = await guarded_fetch("GET", url)
+        resp.raise_for_status()
+        text = str(resp.text)
+        if len(text) > 50_000:
+            text = text[:50_000] + "\n...(truncated to 50KB)"
+        return text
+    except BlockedURLError as exc:
+        return f"Error: blocked URL — {exc}"
     except Exception as exc:
         return f"Error fetching {url}: {exc}"
 
@@ -142,24 +143,23 @@ async def fetch_url(url: str) -> str:
 
 @tool(description="Make an HTTP request (GET/POST/PUT/DELETE)")
 async def http_request(url: str, method: str = "GET", body: str = "") -> str:
-    """Make an HTTP request."""
-    import httpx
+    """Make an HTTP request (public addresses only — see SSRF policy)."""
+    from binex.tools.ssrf import BlockedURLError, guarded_fetch
 
     method = method.upper()
     if method not in ("GET", "POST", "PUT", "DELETE", "PATCH"):
         return f"Error: unsupported method '{method}'"
 
+    send_body = body if body and method in ("POST", "PUT", "PATCH") else None
+    headers = {"Content-Type": "application/json"} if send_body else None
     try:
-        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-            kwargs: dict[str, Any] = {"method": method, "url": url}
-            if body and method in ("POST", "PUT", "PATCH"):
-                kwargs["content"] = body
-                kwargs["headers"] = {"Content-Type": "application/json"}
-            resp = await client.request(**kwargs)
-            text = resp.text
-            if len(text) > 50_000:
-                text = text[:50_000] + "\n...(truncated to 50KB)"
-            return f"HTTP {resp.status_code}\n{text}"
+        resp = await guarded_fetch(method, url, content=send_body, headers=headers)
+        text = str(resp.text)
+        if len(text) > 50_000:
+            text = text[:50_000] + "\n...(truncated to 50KB)"
+        return f"HTTP {resp.status_code}\n{text}"
+    except BlockedURLError as exc:
+        return f"Error: blocked URL — {exc}"
     except Exception as exc:
         return f"Error: {exc}"
 

--- a/src/binex/tools/ssrf.py
+++ b/src/binex/tools/ssrf.py
@@ -1,0 +1,109 @@
+"""SSRF protection for the HTTP built-in tools.
+
+``fetch_url`` / ``http_request`` fetch whatever URL the model produces. On a
+laptop that's low risk, but Binex also ships a gateway and a cron scheduler that
+run on servers — where an LLM-controlled HTTP client can reach cloud metadata
+endpoints (169.254.169.254), localhost admin panels, and internal services.
+
+This module resolves a URL's host and rejects private/loopback/link-local
+addresses before connecting, and re-checks on every redirect hop. See issue #59.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+MAX_REDIRECTS = 5
+
+
+class BlockedURLError(Exception):
+    """Raised when a URL is disallowed by the SSRF policy."""
+
+
+def _ip_is_blocked(ip: str) -> bool:
+    """True for private/loopback/link-local/reserved/multicast addresses."""
+    addr = ipaddress.ip_address(ip)
+    return (
+        addr.is_private        # RFC 1918 (10/8, 172.16/12, 192.168/16), fc00::/7
+        or addr.is_loopback    # 127.0.0.0/8, ::1
+        or addr.is_link_local  # 169.254.0.0/16 (cloud metadata), fe80::/10
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified  # 0.0.0.0, ::
+    )
+
+
+def validate_url(url: str) -> None:
+    """Raise BlockedURLError if the URL targets a non-public address.
+
+    Skipped when ``BINEX_ALLOW_PRIVATE_URLS=1`` (opt-in for legitimate local use).
+    """
+    if os.environ.get("BINEX_ALLOW_PRIVATE_URLS") == "1":
+        return
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise BlockedURLError(f"URL scheme '{parsed.scheme}' is not allowed")
+    host = parsed.hostname
+    if not host:
+        raise BlockedURLError("URL has no host")
+
+    try:
+        infos = socket.getaddrinfo(host, parsed.port or None)
+    except socket.gaierror as exc:
+        raise BlockedURLError(f"cannot resolve host '{host}': {exc}") from exc
+
+    for info in infos:
+        ip = str(info[4][0])
+        if _ip_is_blocked(ip):
+            raise BlockedURLError(
+                f"host '{host}' resolves to blocked address {ip} "
+                f"(private/loopback/link-local). Set BINEX_ALLOW_PRIVATE_URLS=1 "
+                f"to allow local requests."
+            )
+
+
+async def guarded_fetch(
+    method: str,
+    url: str,
+    *,
+    content: str | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 30,
+    max_redirects: int = MAX_REDIRECTS,
+) -> Any:
+    """Perform an HTTP request, validating the address on every redirect hop.
+
+    Redirects are followed manually (httpx auto-redirects are disabled) so each
+    hop's destination is re-validated — a public URL can't 302 into the metadata
+    service.
+    """
+    import httpx
+
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+        current = url
+        current_method = method
+        current_content = content
+        for _ in range(max_redirects + 1):
+            validate_url(current)
+            resp = await client.request(
+                current_method, current,
+                content=current_content if current_content else None,
+                headers=headers,
+            )
+            if resp.status_code in (301, 302, 303, 307, 308):
+                location = resp.headers.get("location")
+                if not location:
+                    return resp
+                current = urljoin(current, location)
+                # 303 (and commonly 301/302) redirect to GET without a body.
+                if resp.status_code in (301, 302, 303):
+                    current_method = "GET"
+                    current_content = None
+                continue
+            return resp
+    raise BlockedURLError(f"too many redirects (>{max_redirects})")

--- a/tests/unit/test_ssrf.py
+++ b/tests/unit/test_ssrf.py
@@ -1,0 +1,119 @@
+"""SSRF protection for fetch_url / http_request (issue #59)."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from binex.tools.builtins import get_builtin
+from binex.tools.ssrf import BlockedURLError, guarded_fetch, validate_url
+
+
+def _fake_getaddrinfo(host, port=None, *args, **kwargs):
+    """Resolve a known public host to a public IP; literal IPs to themselves."""
+    ip = {"public.test": "93.184.216.34", "example.com": "93.184.216.34"}.get(host, host)
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port or 0))]
+
+
+class _FakeResp:
+    def __init__(self, status, headers=None, text=""):
+        self.status_code = status
+        self.headers = headers or {}
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self._i = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        pass
+
+    async def request(self, method, url, **kwargs):
+        resp = self._responses[self._i]
+        self._i += 1
+        return resp
+
+
+# ── validate_url ─────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("url", [
+    "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+    "http://127.0.0.1:8080/admin",               # loopback
+    "http://localhost/",                         # loopback by name
+    "http://10.0.0.5/internal",                  # RFC 1918
+    "http://192.168.1.1/",                       # RFC 1918
+    "http://0.0.0.0/",                           # unspecified
+    "file:///etc/passwd",                        # non-http scheme
+])
+def test_validate_url_blocks(url):
+    with pytest.raises(BlockedURLError):
+        validate_url(url)
+
+
+def test_validate_url_allows_public():
+    with patch("socket.getaddrinfo", _fake_getaddrinfo):
+        validate_url("https://example.com/")  # must not raise
+
+
+def test_dns_rebinding_to_private_blocked():
+    """A public-looking hostname that resolves to a private IP is blocked."""
+    def _resolve_private(host, port=None, *a, **k):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.1.2.3", 0))]
+
+    with patch("socket.getaddrinfo", _resolve_private):
+        with pytest.raises(BlockedURLError):
+            validate_url("http://sneaky.example.com/")
+
+
+def test_opt_out_allows_private(monkeypatch):
+    monkeypatch.setenv("BINEX_ALLOW_PRIVATE_URLS", "1")
+    validate_url("http://127.0.0.1/")  # must not raise
+
+
+# ── redirect re-check ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_redirect_to_internal_is_blocked():
+    """A public URL that 302s to the metadata service is blocked on the hop."""
+    redirect = _FakeResp(302, headers={"location": "http://169.254.169.254/"})
+    with patch("socket.getaddrinfo", _fake_getaddrinfo), \
+         patch("httpx.AsyncClient", lambda *a, **k: _FakeClient([redirect])):
+        with pytest.raises(BlockedURLError):
+            await guarded_fetch("GET", "http://public.test/")
+
+
+@pytest.mark.asyncio
+async def test_public_redirect_followed():
+    """A redirect to another public URL is followed normally."""
+    hop1 = _FakeResp(302, headers={"location": "https://example.com/final"})
+    hop2 = _FakeResp(200, text="OK")
+    with patch("socket.getaddrinfo", _fake_getaddrinfo), \
+         patch("httpx.AsyncClient", lambda *a, **k: _FakeClient([hop1, hop2])):
+        resp = await guarded_fetch("GET", "http://public.test/")
+    assert resp.status_code == 200 and resp.text == "OK"
+
+
+# ── tool integration ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_fetch_url_tool_blocks_metadata():
+    fetch = get_builtin("fetch_url")
+    result = await fetch.callable(url="http://169.254.169.254/latest/meta-data/")
+    assert "blocked URL" in result
+
+
+@pytest.mark.asyncio
+async def test_http_request_tool_blocks_localhost():
+    http = get_builtin("http_request")
+    result = await http.callable(url="http://127.0.0.1:9000/admin", method="GET")
+    assert "blocked URL" in result


### PR DESCRIPTION
Closes #59.

## Problem
`fetch_url` and `http_request` fetched any URL the model produced, with redirects enabled and no address filtering. On a laptop that's low risk — but Binex also ships `binex gateway` and `binex scheduler`, which users deploy on servers. There, an LLM-controlled HTTP client can reach cloud metadata endpoints (`169.254.169.254`), localhost admin panels, and internal network services.

## Fix
- **`tools/ssrf.py`** — `validate_url` resolves the URL's host and rejects any that maps to a **private, loopback, link-local, reserved, multicast, or unspecified** address (RFC 1918, `127.0.0.0/8`, `169.254.0.0/16`, `::1`, `fc00::/7`, `0.0.0.0`). Only `http`/`https` schemes are allowed. This also stops DNS-rebinding — a public-looking hostname that resolves to `10.x` is blocked.
- **Redirect re-check** — `guarded_fetch` disables httpx auto-redirects and follows them manually, **re-validating every hop**, so a public URL can't `302` into the metadata service.
- **Opt-out** — `BINEX_ALLOW_PRIVATE_URLS=1` for legitimate local requests.
- `fetch_url` and `http_request` now route through `guarded_fetch`.

## Verification
- 14 tests: blocks metadata/loopback/RFC1918/unspecified/non-http-scheme; allows public; DNS-rebinding-to-private blocked; opt-out; redirect-to-internal blocked; public redirect followed; tool-level integration for both tools.
- Full unit suite: 2576 passed. ruff clean.

## Note
Response-size cap is still via truncation (body downloaded then truncated) — tightening to a streamed byte cap is a small follow-up noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
