### PR TITLE
fix(security): scaffolded agent server binds to 127.0.0.1 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security
+
+- **Scaffolded agent binds to loopback (#61)** — `binex scaffold agent` generated a `server.py` that ran `uvicorn.run(app, host="0.0.0.0", ...)`, exposing the new agent to the whole local network with no auth. The generated server now defaults to `127.0.0.1` and takes a `--host` flag (mirroring `binex ui`); exposing it is an explicit `--host 0.0.0.0` choice.
+
 ### Features
 
 - **Node caching** — reuse a node's result when nothing that affects its output has changed, so editing a downstream prompt no longer forces re-running (and re-paying for) unchanged upstream nodes. The cache key is a content hash of the agent, resolved prompt, model parameters, tools, and input-artifact content; a hit is served at `$0` with a distinct `node:cache_hit` trace event pointing to the source run. Opt-in via per-node `cache: true` or run-level `binex run --cache`; `binex run --offline` runs only from cache (a miss fails the node — VCR-style iteration). New `binex clean cache [--older-than DAYS] [--dry-run]` clears the cache. (#68)

--- a/docs/features/security.md
+++ b/docs/features/security.md
@@ -15,6 +15,16 @@ Binex built-in tools run with the permissions of the orchestrator process. Two t
 - Output truncated to 10KB
 - No shell expansion (`|`, `&&`, `;`, backticks have no effect)
 
+### Scaffolded agent server — network exposure (patched, issue #61)
+
+**Before:** `binex scaffold agent` generated a `server.py` that ran
+`uvicorn.run(app, host="0.0.0.0", ...)` — exposing the new agent to the whole
+local network, with no auth, the moment it was started.
+
+**After:** the generated server binds to `127.0.0.1` by default and accepts a
+`--host` flag (mirroring `binex ui`). Exposing it on the network is now an
+explicit `--host 0.0.0.0` decision.
+
 ### calculator — Arbitrary Code Execution (CRITICAL, patched)
 
 **Before:** Used raw `eval(expression)` — any agent could execute arbitrary Python code.

--- a/src/binex/cli/scaffold.py
+++ b/src/binex/cli/scaffold.py
@@ -147,7 +147,16 @@ async def health():
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the {name} agent server")
+    parser.add_argument(
+        "--host", default="127.0.0.1",
+        help="Host to bind (default: 127.0.0.1; use 0.0.0.0 to expose on the network)",
+    )
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    args = parser.parse_args()
+    uvicorn.run(app, host=args.host, port=args.port)
 '''
 
 

--- a/tests/unit/test_cli_scaffold.py
+++ b/tests/unit/test_cli_scaffold.py
@@ -53,6 +53,21 @@ class TestScaffoldAgent:
         server_py = (target / "server.py").read_text()
         assert "cool-bot" in server_py or "cool_bot" in server_py
 
+    def test_server_binds_loopback_by_default(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        target = tmp_path / "safebot"
+        result = runner.invoke(
+            scaffold_group, ["agent", "--name", "safebot", "--dir", str(target)],
+        )
+        assert result.exit_code == 0
+
+        server_py = (target / "server.py").read_text()
+        # Must not expose on all interfaces by default; --host lets you opt in.
+        assert 'host="0.0.0.0"' not in server_py
+        assert '"127.0.0.1"' in server_py
+        assert "--host" in server_py
+        compile(server_py, "server.py", "exec")  # generated file is valid Python
+
     def test_dir_flag_changes_target_directory(self, tmp_path: Path) -> None:
         runner = CliRunner()
         custom_dir = tmp_path / "custom" / "location"


### PR DESCRIPTION
Closes #61.

## Problem
`binex scaffold agent` generated a `server.py` whose `__main__` ran `uvicorn.run(app, host="0.0.0.0", port=8000)` — exposing the freshly scaffolded agent to the entire local network, with no auth, as soon as the user ran it. (`binex ui` already defaults to `127.0.0.1` with a `--host` option.)

## Fix
The generated `server.py` now binds to `127.0.0.1` by default and accepts `--host` / `--port` via argparse. Exposing on the network is an explicit `--host 0.0.0.0` decision.

## Verification
- New test: generated `server.py` has no `0.0.0.0` default, binds `127.0.0.1`, exposes `--host`, compiles as valid Python.
- Full unit suite: 2563 passed. ruff clean.

Note: corrected the issue reference — this fixes #61 (scaffold bind), not #60 (which is the eval/regression issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)