### PR TITLE
test(ui): fix 11 stale frontend tests (green vitest suite)

### DIFF
--- a/ui/src/components/editor/CaoNodePanel.test.tsx
+++ b/ui/src/components/editor/CaoNodePanel.test.tsx
@@ -28,34 +28,31 @@ function makeProps(overrides: Partial<CaoNodePanelProps> = {}): CaoNodePanelProp
 }
 
 describe('CaoNodePanel', () => {
+  // useCAOProfiles hardcodes retry:1, so the error state arrives after the
+  // retry delay (~1s) — give findBy* a longer timeout than the 1s default.
+  const FALLBACK_TIMEOUT = { timeout: 4000 };
+
   it('renders fallback input when server is unavailable', async () => {
     render(<CaoNodePanel {...makeProps()} />, { wrapper: createWrapper() });
-    // Wait for query to fail
-    expect(await screen.findByText(/CAO server unavailable/i)).toBeInTheDocument();
+    // Wait for query to fail (after its retry)
+    expect(
+      await screen.findByText(/CAO server unavailable/i, {}, FALLBACK_TIMEOUT),
+    ).toBeInTheDocument();
     expect(screen.getByPlaceholderText('profile_name.md')).toBeInTheDocument();
   });
 
   it('calls onAgentChange when manual profile is typed', async () => {
     const onAgentChange = vi.fn();
     render(<CaoNodePanel {...makeProps({ onAgentChange })} />, { wrapper: createWrapper() });
-    const input = await screen.findByPlaceholderText('profile_name.md');
+    const input = await screen.findByPlaceholderText(
+      'profile_name.md', {}, FALLBACK_TIMEOUT,
+    );
     fireEvent.change(input, { target: { value: 'my-agent' } });
     expect(onAgentChange).toHaveBeenCalledWith('cao://my-agent');
   });
 
-  it('renders Handoff radio as checked by default', () => {
-    render(<CaoNodePanel {...makeProps()} />, { wrapper: createWrapper() });
-    const handoffRadio = screen.getByLabelText('Handoff');
-    expect(handoffRadio).toBeChecked();
-  });
-
-  it('renders disabled Assign and SendMessage radios', () => {
-    render(<CaoNodePanel {...makeProps()} />, { wrapper: createWrapper() });
-    const assignRadio = screen.getByLabelText('Assign');
-    const sendMessageRadio = screen.getByLabelText('SendMessage');
-    expect(assignRadio).toBeDisabled();
-    expect(sendMessageRadio).toBeDisabled();
-  });
+  // NOTE: the Handoff/Assign/SendMessage mode radios were removed from the panel;
+  // their tests were removed with them.
 
   it('calls onConfigChange for output format change', () => {
     const onConfigChange = vi.fn();

--- a/ui/src/components/editor/EditorToolbar.test.tsx
+++ b/ui/src/components/editor/EditorToolbar.test.tsx
@@ -30,7 +30,7 @@ describe('EditorToolbar', () => {
   it('renders Save and Run buttons', () => {
     render(<EditorToolbar {...makeProps()} />);
     expect(screen.getByText('Save')).toBeInTheDocument();
-    expect(screen.getByText('Run')).toBeInTheDocument();
+    expect(screen.getByText('▸ Run')).toBeInTheDocument();
   });
 
   it('shows selected file path', () => {
@@ -50,12 +50,12 @@ describe('EditorToolbar', () => {
 
   it('shows unsaved indicator when dirty', () => {
     render(<EditorToolbar {...makeProps({ isDirty: true })} />);
-    expect(screen.getByText('(unsaved)')).toBeInTheDocument();
+    expect(screen.getByText('unsaved')).toBeInTheDocument();
   });
 
   it('hides unsaved indicator when not dirty', () => {
     render(<EditorToolbar {...makeProps({ isDirty: false })} />);
-    expect(screen.queryByText('(unsaved)')).not.toBeInTheDocument();
+    expect(screen.queryByText('unsaved')).not.toBeInTheDocument();
   });
 
   it('calls onSwitchToVisual when Visual clicked', async () => {
@@ -86,7 +86,7 @@ describe('EditorToolbar', () => {
     const user = userEvent.setup();
     const props = makeProps();
     render(<EditorToolbar {...props} />);
-    await user.click(screen.getByText('Run'));
+    await user.click(screen.getByText('▸ Run'));
     expect(props.onRun).toHaveBeenCalledOnce();
   });
 
@@ -97,17 +97,17 @@ describe('EditorToolbar', () => {
 
   it('disables Run when no content', () => {
     render(<EditorToolbar {...makeProps({ hasContent: false })} />);
-    expect(screen.getByText('Run').closest('button')).toBeDisabled();
+    expect(screen.getByText('▸ Run').closest('button')).toBeDisabled();
   });
 
   it('shows "Saving..." when isSaving', () => {
     render(<EditorToolbar {...makeProps({ isSaving: true })} />);
-    expect(screen.getByText('Saving...')).toBeInTheDocument();
+    expect(screen.getByText('Saving…')).toBeInTheDocument();
   });
 
   it('shows "Starting..." when isRunning', () => {
     render(<EditorToolbar {...makeProps({ isRunning: true })} />);
-    expect(screen.getByText('Starting...')).toBeInTheDocument();
+    expect(screen.getByText('Starting…')).toBeInTheDocument();
   });
 
   it('calls onOpenFiles when Open clicked', async () => {

--- a/ui/src/components/trace/TraceGantt.test.tsx
+++ b/ui/src/components/trace/TraceGantt.test.tsx
@@ -56,7 +56,7 @@ describe('TraceGantt', () => {
     const { container } = render(
       <TraceGantt timeline={entries} totalDuration={2.0} anomalyNodeIds={new Set()} />,
     );
-    const labels = container.querySelectorAll('.font-mono.text-slate-400');
+    const labels = container.querySelectorAll('.font-mono.text-right');
     expect(labels[0]?.textContent).toBe('first');
     expect(labels[1]?.textContent).toBe('second');
   });


### PR DESCRIPTION
Greens up the frontend `vitest` suite: **133 passed / 11 failed → 142 passed / 0 failed**. These tests had drifted from the components they cover — **no product code changed, only tests.**

## What was stale and why
- **EditorToolbar (6 tests)** — the toolbar was polished: `▸ Run` (was `Run`), unicode ellipsis `Saving…` / `Starting…` (were `Saving...`), and `unsaved` without parens. The tests still matched the old ASCII labels → updated to the current rendering.
- **CaoNodePanel (4 tests)** —
  - 2 timed out: `useCAOProfiles` hardcodes `retry: 1`, so the error/fallback state only appears after react-query's retry delay (>1s), past `findBy*`'s 1s default → bumped the timeout.
  - 2 tested the **Handoff / Assign / SendMessage** mode radios, which were **removed** from the panel → deleted the stale tests.
- **TraceGantt (1 test)** — the row-label selector `.font-mono.text-slate-400` no longer matches (the label class is now `text-[#80808a]`) → switched to the stable `.font-mono.text-right`.

## Checks
- `vitest`: **142 passed / 0 failed**.
- `tsc -b` clean, `eslint` clean on the changed files.
