### PR TITLE
docs: framework comparison (#28) + Debugging & Observability guide (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Documentation
+
+- **Framework comparison** — a `docs/comparison.md` (and a short table in the README) covering Binex vs. LangGraph / CrewAI / AutoGen, honest about where each tool's weight sits: the others build agents, Binex debugs them. (#28)
+- **Debugging & Observability guide** — a single `docs/guides/debugging.md` that walks the whole toolkit end-to-end (debug → trace → diagnose → diff/semantic → bisect → eval → cost → replay → observer), with a "which tool, when" table, so new users see the full power available. (#30)
+
 ### Security
 
 - **Scaffolded agent binds to loopback (#61)** — `binex scaffold agent` generated a `server.py` that ran `uvicorn.run(app, host="0.0.0.0", ...)`, exposing the new agent to the whole local network with no auth. The generated server now defaults to `127.0.0.1` and takes a `--host` flag (mirroring `binex ui`); exposing it is an explicit `--host 0.0.0.0` choice.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ That's it. Browser opens. You're building AI workflows.
 - **Full debuggability** — every input, output, prompt, and cost is visible
 - **Any model** — OpenAI, Anthropic, Google, Ollama, OpenRouter, DeepSeek, and 40+ more via LiteLLM
 
+### How it compares
+
+LangGraph, CrewAI, and AutoGen are frameworks for **building** agents. Binex is a
+**debuggable runtime** — it competes on everything *after* "run": trace, cost,
+diff, bisect, replay, and regression gates, all local.
+
+| Capability | Binex | LangGraph | CrewAI | AutoGen |
+|---|:---:|:---:|:---:|:---:|
+| Built-in trace / replay / diff / bisect | ✅ | ⚠️ hosted (LangSmith) | ❌ | ❌ |
+| Per-node / per-call cost tracking | ✅ | ⚠️ | ⚠️ | ⚠️ |
+| Regression safety net (eval + golden-run diff) | ✅ | ❌ | ❌ | ❌ |
+| Visual editor **and** CLI | ✅ | ⚠️ Studio | ❌ | ⚠️ Studio |
+| YAML workflows | ✅ | ❌ | ⚠️ | ❌ |
+| Debug an existing run **without migrating** | ✅ observer | ❌ | ❌ | ❌ |
+| Local-first, no cloud | ✅ | ✅ | ✅ | ✅ |
+
+They also compose — point Binex's `observe()` at an existing CrewAI/LangGraph
+run to get its debugging without migrating. Full breakdown, including where each
+tool shines, in [docs/comparison.md](docs/comparison.md).
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ---

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,62 @@
+# Binex vs. LangGraph, CrewAI & AutoGen
+
+"Why Binex over LangGraph / CrewAI / AutoGen?" — the honest answer is that they
+solve *different* problems. The other three are frameworks for **building** agent
+systems. Binex is a **debuggable runtime** for them: its whole reason for
+existing is that once an agent workflow runs, you can see exactly what happened
+and iterate without guessing.
+
+So the table below isn't "Binex wins" — it's "here's where each tool's weight
+sits." Use Binex when observability, local iteration, and reproducibility are
+the pain; reach for the others when their agent abstractions are what you need
+(and consider [observer mode](features/observer-mode.md) to get Binex's
+debugging *on top of* an existing CrewAI project without migrating).
+
+## At a glance
+
+| Capability | Binex | LangGraph | CrewAI | AutoGen |
+|---|:---:|:---:|:---:|:---:|
+| Local-first, no cloud required | ✅ | ✅ *(runtime)* | ✅ | ✅ |
+| Built-in trace / replay / diff / bisect | ✅ | ⚠️ *(via LangSmith, hosted)* | ❌ | ❌ |
+| Per-node / per-call cost tracking | ✅ | ⚠️ *(LangSmith)* | ⚠️ *(usage only)* | ⚠️ |
+| Visual editor **and** CLI | ✅ | ⚠️ *(LangGraph Studio)* | ❌ | ⚠️ *(AutoGen Studio)* |
+| YAML-declared workflows | ✅ | ❌ *(Python graph)* | ⚠️ *(YAML for crews)* | ❌ *(Python)* |
+| Model-agnostic | ✅ *(LiteLLM, 100+)* | ✅ *(LangChain)* | ✅ *(LiteLLM)* | ✅ |
+| Regression safety net (eval assertions + golden-run diff) | ✅ | ❌ | ❌ | ❌ |
+| Debug an existing run **without migrating** | ✅ *([observer](features/observer-mode.md))* | ❌ | ❌ | ❌ |
+| Rich agent-orchestration abstractions | ⚠️ *(patterns)* | ✅ | ✅ *(roles/tasks)* | ✅ *(conversations)* |
+| Large ecosystem / integrations | ⚠️ | ✅ | ⚠️ | ✅ |
+
+✅ first-class · ⚠️ partial / add-on / hosted · ❌ not a focus
+
+## Where each one shines
+
+- **LangGraph** — the most flexible way to express **stateful, cyclic** agent
+  graphs in Python, with a deep LangChain ecosystem. Its observability
+  (LangSmith) is excellent but hosted and separate; tracing/eval largely live in
+  that paid, cloud product.
+- **CrewAI** — the fastest way to stand up a **role-based crew** ("researcher →
+  writer → editor"). Great ergonomics; the trade-off is that a crew runs as one
+  opaque unit, and per-agent cost/trace is hard to see. Binex's
+  [observer mode](features/observer-mode.md) exists precisely for CrewAI users.
+- **AutoGen** — strong for **conversational, multi-agent** problem solving and
+  research, backed by Microsoft, with AutoGen Studio for a no-code UI.
+- **Binex** — not competing to *author* the smartest agent. It competes on
+  everything *after* "run": trace, per-node/per-call cost, `diff`/`bisect`
+  between runs, single-node/single-call [replay](cli/replay.md), eval
+  [assertions](features/eval.md) as a pre-merge safety net, a git-snapshotted
+  [workspace](features/workspace.md), and a local Web UI — all local, no account.
+
+## The honest summary
+
+- Building a novel agent architecture from scratch, or already deep in the
+  LangChain ecosystem → **LangGraph**.
+- Shipping a role-based crew fast → **CrewAI** (and point `observe()` at it for
+  visibility).
+- Conversational multi-agent research in the Microsoft stack → **AutoGen**.
+- You have workflows that *run* and you're tired of "why did today's run behave
+  differently?" — you want trace, cost, diff, bisect, replay, and regression
+  gates, locally and privately → **Binex**.
+
+They also compose: keep your CrewAI/LangGraph logic and use Binex to observe,
+diff, and replay it.

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -1,0 +1,117 @@
+# Debugging & Observability guide
+
+Binex's reason for existing is what happens *after* a workflow runs. This guide
+walks the full toolkit end-to-end — which tool to reach for, the CLI command,
+and where it lives in the Web UI (`binex ui`). Every one of these is local and
+private; nothing leaves your machine.
+
+## Which tool, when
+
+| You want to… | Reach for | CLI |
+|---|---|---|
+| See what each node did, and why one failed | **Debug** | `binex debug <run>` |
+| See the run as a timeline, spot slow/anomalous nodes | **Trace** | `binex trace <run>` |
+| Get a root-cause hypothesis for a failure | **Diagnose** | `binex diagnose <run>` |
+| Compare two runs node-by-node | **Diff** | `binex diff <a> <b>` |
+| Tell *meaningful* output changes from rewording | **Semantic diff** | `binex diff <a> <b> --semantic` |
+| Find which node — or which commit — broke quality | **Bisect** | `binex bisect …` |
+| Gate against regressions before merge | **Eval** | `binex eval <workflow>` |
+| See where the money went | **Cost** | `binex cost show <run>` |
+| Try a different model/prompt on the same input | **Replay** | `binex replay …` |
+| Debug an existing CrewAI run without migrating it | **Observer** | `observe()` + `binex ui` |
+
+## 1. Debug a failed run
+
+Start here. `binex debug <run-id>` (or `binex debug latest`) prints each node's
+status, agent, prompt, output, timing, error, and — for runs with a
+[workspace](../features/workspace.md) — the files it changed. In the Web UI, the
+**Debug** tab gives the same per-node view, with inline previews for
+[binary artifacts](../features/binary-artifacts.md) (images, audio, PDFs).
+
+```bash
+binex debug latest --errors      # only the failed/timed-out nodes
+binex debug <run-id> --json      # machine-readable
+```
+
+## 2. Trace the timeline
+
+`binex trace <run-id>` shows the run as a Gantt-style timeline — when each node
+started, how long it took, and which nodes ran in parallel. The Web UI **Trace**
+tab flags **anomalies** (nodes far slower than their peers) so a stall is obvious
+at a glance.
+
+## 3. Diagnose the root cause
+
+`binex diagnose <run-id>` looks past the *first* error to the *root* one — the
+node whose failure cascaded — and summarizes the failure pattern, so you fix the
+cause, not a symptom.
+
+## 4. Compare two runs
+
+`binex diff <run-a> <run-b>` compares two runs node-by-node: status changes,
+latency/cost deltas, and content differences. Textual diffs are noisy for LLM
+output, so `--semantic` asks a cheap model **narrow questions** (did the
+structure change? the facts? only the wording?) and flags *meaningful* changes
+while collapsing cosmetic rewording — at temperature 0, with a confidence per
+verdict, and it's strictly opt-in with the cost shown before it runs. See
+[semantic diff](../cli/diff.md#semantic-diff-semantic).
+
+## 5. Bisect a regression
+
+Two granularities:
+
+- **Across nodes** — `binex bisect <good-run> <bad-run>` finds the first node
+  where two runs diverge.
+- **Across git history** — `binex bisect history -w <workflow> --good <ref>
+  --bad <ref>` binary-searches your commits, re-running the workflow at each and
+  judging pass/fail with an eval criterion, to pinpoint the commit that broke
+  quality (each probe runs in an isolated git worktree; see
+  [bisect](../cli/bisect.md)).
+
+## 6. Prevent regressions (eval)
+
+Turn diff/bisect from post-mortem into a **pre-merge safety net**. Declare
+block-on [assertions](../features/eval.md) on nodes (contains / lacks / regex /
+cost & latency ceilings / an LLM-as-judge rubric), then `binex eval <workflow>`
+exits non-zero on any failure; `--baseline <run-id>` also diffs against a golden
+run. Drop it into CI on PRs that touch prompts or workflow YAML.
+
+## 7. Track costs
+
+`binex cost show <run-id>` breaks spend down per node; the Web UI **Cost
+Dashboard** aggregates across runs, by model and over time. `binex cost simulate`
+estimates what a run *would* cost on a different model — with zero LLM calls —
+from its stored token counts.
+
+## 8. Replay with changes
+
+The dominant iteration loop is "this node answered badly → try another
+prompt/model on the same input." `binex replay <run> --from <node> --agent
+<node>=llm://…` re-runs from a node with swaps. For an
+[observed](../features/observer-mode.md) run, `binex replay <run> --call
+<call-id> --model X` replays a **single captured call** and shows the original
+vs. new response side by side (cost tracked separately as experimentation).
+
+## 9. Observe an existing run (no migration)
+
+If your workflow lives in CrewAI (or any LiteLLM-backed code), you don't have to
+port it. Wrap it:
+
+```python
+from binex import observe
+
+with observe("my-crew-run"):
+    crew.kickoff()
+```
+
+Then open `binex ui` (or `binex debug my-crew-run`) for the trace, per-call cost
+breakdown, and response artifacts — on untouched code. Every tool above then
+works on that observed run. Try it offline first with `binex observe-demo`. See
+[observer mode](../features/observer-mode.md).
+
+## Put it together
+
+A typical loop: a run misbehaves → **debug** to see the failing node → **trace**
+if it was slow → **diagnose** for the root cause → **diff** (or **bisect**) an
+old good run against it → **replay** a fix on the offending node → add an **eval
+assertion** so it can't regress again → watch **cost** the whole time.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,9 @@ nav:
   - Home: index.md
   - Demo: demo.md
   - Quickstart: quickstart.md
+  - Comparison: comparison.md
+  - Guides:
+    - Debugging & Observability: guides/debugging.md
   - Concepts:
     - Agents: concepts/agents.md
     - Workflows: concepts/workflows.md


### PR DESCRIPTION
Closes #28 and #30 — two documentation issues.

## #28 — Framework comparison
`docs/comparison.md` plus a short table in the README: **Binex vs. LangGraph / CrewAI / AutoGen**. Kept honest rather than a marketing sheet — the framing is "the other three *build* agents; Binex is a debuggable *runtime* for them." Includes a capability matrix (trace/replay/diff/bisect, per-node cost, eval regression gates, visual editor + CLI, YAML, observe-without-migrating, local-first), a "where each one shines" section that credits the competitors' strengths, and a note that they **compose** (point `observe()` at an existing CrewAI/LangGraph run).

## #30 — Unified Debugging & Observability guide
`docs/guides/debugging.md`: a single page that walks the whole toolkit end-to-end — **debug → trace → diagnose → diff / semantic diff → bisect → eval → cost → replay → observer** — each with the CLI command and where it lives in the Web UI. Opens with a "which tool, when" table and closes with a "put it together" loop, so new users discover the full power instead of hunting through separate `cli/` pages.

## Wiring
- `mkdocs.yml` — new **Comparison** page and a **Guides** section.
- `README.md` — a compact comparison table under "Why Binex?", linking to the full doc.

## Checks
- `mkdocs build --strict` passes (verified with the repo's plugin set); all internal links in both new pages resolve. Docs-only — no code changes.
