### PR TITLE
fix(api): support last_n in export endpoint (closes #112)

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -117,10 +117,6 @@ Fixtures `sidebar` and `export_page` are provided by `tests/e2e_playwright/conft
 
 `conftest.py` also injects `TOUR_DISMISSED_STATE` as `storage_state` so the onboarding tour never overlays elements under test.
 
-### Known xfail
-
-`test_export.py` marks the "last N runs" export mode as `xfail` — BUG [#112](https://github.com/Alexli18/binex/issues/112): `/api/v1/export` requires `run_ids` and has no `last_n` support.
-
 ## Async Test Configuration
 
 All async tests are auto-detected. The `pyproject.toml` sets:

--- a/src/binex/ui/api/export.py
+++ b/src/binex/ui/api/export.py
@@ -29,9 +29,13 @@ def _get_stores() -> tuple[
 
 
 class ExportRequest(BaseModel):
-    """Request body for data export."""
+    """Request body for data export.
 
-    run_ids: list[str]
+    Exactly one of ``run_ids`` or ``last_n`` must be provided.
+    """
+
+    run_ids: list[str] | None = None
+    last_n: int | None = None
     format: str = "json"  # "json" or "csv"
     include_artifacts: bool = False
 
@@ -66,7 +70,16 @@ def _write_csv(rows: list[dict[str, Any]]) -> str:
 @router.post("", response_model=None)
 async def export_data(body: ExportRequest) -> StreamingResponse | JSONResponse:
     """Export run data as JSON or CSV (zip)."""
-    if not body.run_ids:
+    if (body.run_ids is None) == (body.last_n is None):
+        return JSONResponse(
+            {"error": "Provide exactly one of run_ids or last_n"},
+            status_code=422,
+        )
+
+    if body.last_n is not None and body.last_n < 1:
+        return JSONResponse({"error": "last_n must be >= 1"}, status_code=422)
+
+    if body.run_ids is not None and not body.run_ids:
         return JSONResponse({"error": "run_ids must not be empty"}, status_code=422)
 
     if body.format not in ("json", "csv"):
@@ -77,12 +90,21 @@ async def export_data(body: ExportRequest) -> StreamingResponse | JSONResponse:
 
     exec_store, artifact_store = _get_stores()
     try:
+        if body.last_n is not None:
+            # list_runs() guarantees no ordering (bare SELECT in sqlite,
+            # insertion order in memory) — sort here, newest first.
+            all_runs = await exec_store.list_runs()
+            all_runs.sort(key=lambda r: r.started_at, reverse=True)
+            run_ids = [r.run_id for r in all_runs[: body.last_n]]
+        else:
+            run_ids = body.run_ids or []
+
         runs = []
         all_records = []
         all_costs = []
         not_found = []
 
-        for run_id in body.run_ids:
+        for run_id in run_ids:
             run = await exec_store.get_run(run_id)
             if run is None:
                 not_found.append(run_id)
@@ -94,8 +116,9 @@ async def export_data(body: ExportRequest) -> StreamingResponse | JSONResponse:
             all_costs.extend(costs)
 
         if not runs:
+            detail = f": {', '.join(not_found)}" if not_found else ""
             return JSONResponse(
-                {"error": f"No runs found: {', '.join(not_found)}"},
+                {"error": f"No runs found{detail}"},
                 status_code=404,
             )
 

--- a/tests/e2e_playwright/test_export.py
+++ b/tests/e2e_playwright/test_export.py
@@ -18,11 +18,6 @@ def test_export_selected_runs(export_page: ExportPage, export_format: ExportForm
     assert download.path().stat().st_size > 0
 
 
-@pytest.mark.xfail(
-    reason="BUG #112: /api/v1/export has no last_n support — ExportRequest requires run_ids, "
-    "frontend sends {last_n} in 'Last N runs' mode and gets 422",
-    strict=True,
-)
 def test_export_last_n(export_page: ExportPage) -> None:
     export_page.goto()
     export_page.select_export_mode_last_n(1)

--- a/tests/unit/test_ui_api_export.py
+++ b/tests/unit/test_ui_api_export.py
@@ -1,0 +1,151 @@
+"""Tests for the export API endpoint (run_ids and last_n modes)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from binex.models.execution import RunSummary
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+from binex.ui.server import create_app
+
+
+@pytest.fixture
+def stores():
+    exec_store = InMemoryExecutionStore()
+    art_store = InMemoryArtifactStore()
+    return exec_store, art_store
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _make_run(run_id: str = "run-1", **kwargs) -> RunSummary:
+    defaults = dict(
+        run_id=run_id,
+        workflow_name="test-workflow",
+        status="completed",
+        started_at=datetime(2026, 1, 1, tzinfo=UTC),
+        total_nodes=3,
+        completed_nodes=3,
+    )
+    defaults.update(kwargs)
+    return RunSummary(**defaults)
+
+
+def _patch_stores(stores):
+    return patch("binex.ui.api.export._get_stores", return_value=stores)
+
+
+@pytest.mark.asyncio
+async def test_export_last_n_returns_most_recent(client, stores):
+    exec_store, _ = stores
+    # Inserted out of chronological order on purpose — last_n must sort
+    # by started_at, not rely on store insertion order.
+    await exec_store.create_run(
+        _make_run("run-old", started_at=datetime(2026, 1, 1, tzinfo=UTC))
+    )
+    await exec_store.create_run(
+        _make_run("run-newest", started_at=datetime(2026, 1, 3, tzinfo=UTC))
+    )
+    await exec_store.create_run(
+        _make_run("run-mid", started_at=datetime(2026, 1, 2, tzinfo=UTC))
+    )
+
+    with _patch_stores(stores):
+        resp = await client.post("/api/v1/export", json={"last_n": 2, "format": "json"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    exported_ids = [r["run_id"] for r in data["runs"]]
+    assert exported_ids == ["run-newest", "run-mid"]
+
+
+@pytest.mark.asyncio
+async def test_export_last_n_greater_than_total_exports_all(client, stores):
+    exec_store, _ = stores
+    await exec_store.create_run(_make_run("run-1"))
+    await exec_store.create_run(
+        _make_run("run-2", started_at=datetime(2026, 1, 2, tzinfo=UTC))
+    )
+
+    with _patch_stores(stores):
+        resp = await client.post("/api/v1/export", json={"last_n": 10, "format": "json"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert {r["run_id"] for r in data["runs"]} == {"run-1", "run-2"}
+
+
+@pytest.mark.asyncio
+async def test_export_both_run_ids_and_last_n_rejected(client, stores):
+    with _patch_stores(stores):
+        resp = await client.post(
+            "/api/v1/export", json={"run_ids": ["run-1"], "last_n": 1}
+        )
+
+    assert resp.status_code == 422
+    assert "exactly one" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_export_neither_run_ids_nor_last_n_rejected(client, stores):
+    with _patch_stores(stores):
+        resp = await client.post("/api/v1/export", json={})
+
+    assert resp.status_code == 422
+    assert "exactly one" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_export_last_n_zero_rejected(client, stores):
+    with _patch_stores(stores):
+        resp = await client.post("/api/v1/export", json={"last_n": 0})
+
+    assert resp.status_code == 422
+    assert "last_n" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_export_last_n_empty_store_returns_404(client, stores):
+    with _patch_stores(stores):
+        resp = await client.post("/api/v1/export", json={"last_n": 5})
+
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "No runs found"
+
+
+@pytest.mark.asyncio
+async def test_export_run_ids_still_works(client, stores):
+    exec_store, _ = stores
+    await exec_store.create_run(_make_run("run-1"))
+
+    with _patch_stores(stores):
+        resp = await client.post(
+            "/api/v1/export", json={"run_ids": ["run-1"], "format": "json"}
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [r["run_id"] for r in data["runs"]] == ["run-1"]
+
+
+@pytest.mark.asyncio
+async def test_export_empty_run_ids_rejected(client, stores):
+    with _patch_stores(stores):
+        resp = await client.post("/api/v1/export", json={"run_ids": []})
+
+    assert resp.status_code == 422
+    assert resp.json()["error"] == "run_ids must not be empty"


### PR DESCRIPTION
## Summary

Fixes #112 — `POST /api/v1/export` rejected the frontend's "Last N runs" mode with a 422 because `ExportRequest` required `run_ids` and had no `last_n` field.

- **Schema**: `run_ids` is now optional, new `last_n: int | None`; exactly one of the two must be provided. Validation lives in the handler (not a pydantic validator) so errors keep the `{"error": ...}` shape the frontend renders via `err.error` — a pydantic validator would surface as FastAPI's `{"detail": [...]}` and degrade to a bare "Unprocessable Entity" in the UI.
- **Handler**: the `last_n` branch fetches all runs, sorts by `started_at` descending in the handler (neither the SQLite nor the in-memory `list_runs()` guarantees ordering — bare `SELECT` / dict insertion order), takes the newest N and feeds them into the existing export loop. Same approach as the CLI (`export_cmd.py`). Also fixed a dangling-colon 404 message (`"No runs found: "`) when the store is empty.
- **Tests**: new `tests/unit/test_ui_api_export.py` (8 cases) following the `test_ui_api_runs.py` pattern — last_n happy path asserting the *newest* runs win over insertion order, last_n > total, both fields → 422, neither → 422, last_n=0 → 422, empty store → 404, plus run_ids-mode regressions.
- **E2E**: `test_export_last_n` went **XPASS(strict)** after the fix — marker removed, test is now a regular green (3/3 in `test_export.py`). Stale "Known xfail" section dropped from `docs/contributing/testing.md`.

## Test plan

- [x] `pytest tests/unit/test_ui_api_export.py` — 8 passed
- [x] `pytest tests/unit` — 2778 passed, 1 skipped
- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/e2e_playwright/test_export.py -m e2e` against a live server with the fix — 3 passed, downloaded file non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)