### PR TITLE
test(api): cover tools, system, scheduler, gateway and cao UI routers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ dev = [
     "mypy",
     "mkdocs-material",
     "pytest-playwright",
-    "pytest-xdist"
+    "pytest-xdist",
+    "respx"
 ]
 rich = ["rich"]
 langchain = ["langchain-core>=0.2"]

--- a/tests/unit/ui_api/test_ui_api_cao.py
+++ b/tests/unit/ui_api/test_ui_api_cao.py
@@ -1,0 +1,319 @@
+"""Tests for the CAO adapter API endpoints.
+
+Covers health, server lifecycle, profiles, sessions, and HITL input.
+"""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import respx
+
+import binex.ui.api.cao as cao_api
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+CAO_URL = "http://cao.test"
+
+
+@pytest.fixture(autouse=True)
+def _cao_env(monkeypatch, tmp_path):
+    # Settings() is re-read in every handler; pointing the server URL at a
+    # fake host makes respx routes unambiguous and guarantees no test can
+    # accidentally talk to a real CAO server on localhost:9889.
+    monkeypatch.setenv("BINEX_CAO_SERVER_URL", CAO_URL)
+    monkeypatch.setenv("BINEX_CAO_AGENT_STORE", str(tmp_path / "agent-store"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_cao_process():
+    cao_api._cao_process = None
+    yield
+    cao_api._cao_process = None
+
+
+def _mock_proc(pid: int = 9001, alive: bool = True) -> MagicMock:
+    # spec=Popen catches typo'd method names; pid is an instance attribute
+    # (absent from the class spec) and must be assigned explicitly.
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = pid
+    proc.poll.return_value = None if alive else 1
+    proc.wait.return_value = 0
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# GET /cao/health
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_health_online(client):
+    route = respx.get(f"{CAO_URL}/health").mock(return_value=httpx.Response(200))
+
+    resp = await client.get("/api/v1/cao/health")
+
+    assert resp.json() == {"status": "online", "server_url": CAO_URL}
+    assert route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_health_degraded_on_non_200(client):
+    respx.get(f"{CAO_URL}/health").mock(return_value=httpx.Response(500))
+
+    resp = await client.get("/api/v1/cao/health")
+
+    assert resp.json() == {
+        "status": "degraded",
+        "server_url": CAO_URL,
+        "http_status": 500,
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_health_offline_on_connect_error(client):
+    respx.get(f"{CAO_URL}/health").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    resp = await client.get("/api/v1/cao/health")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "offline", "server_url": CAO_URL}
+
+
+# ---------------------------------------------------------------------------
+# POST /cao/server/start, /cao/server/stop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_server_start_with_own_process_alive(client):
+    # Own subprocess alive → early return, no HTTP probe, no new Popen.
+    cao_api._cao_process = _mock_proc(pid=9001)
+
+    resp = await client.post("/api/v1/cao/server/start")
+
+    assert resp.json() == {"status": "already_running", "pid": 9001}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_server_start_detects_external_server(client):
+    respx.get(f"{CAO_URL}/health").mock(return_value=httpx.Response(200))
+
+    resp = await client.post("/api/v1/cao/server/start")
+
+    assert resp.json() == {
+        "status": "already_running",
+        "message": "CAO server is already running externally",
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_server_start_binary_missing(client):
+    respx.get(f"{CAO_URL}/health").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    with patch("binex.ui.api.cao.shutil.which", return_value=None):
+        resp = await client.post("/api/v1/cao/server/start")
+
+    assert resp.status_code == 400
+    assert "cao-server not found" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_server_start_success(client):
+    respx.get(f"{CAO_URL}/health").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+    proc = _mock_proc(pid=9002)
+
+    with (
+        patch("binex.ui.api.cao.shutil.which", return_value="/usr/bin/cao-server"),
+        patch("binex.ui.api.cao.subprocess.Popen", return_value=proc) as popen,
+        patch("asyncio.sleep", new_callable=AsyncMock),  # skip the 1s startup wait
+    ):
+        resp = await client.post("/api/v1/cao/server/start")
+
+    assert resp.json() == {"status": "started", "pid": 9002}
+    assert popen.call_args[0][0] == ["/usr/bin/cao-server"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_server_start_reports_immediate_death(client):
+    respx.get(f"{CAO_URL}/health").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+    proc = _mock_proc(pid=9003, alive=False)
+
+    with (
+        patch("binex.ui.api.cao.shutil.which", return_value="/usr/bin/cao-server"),
+        patch("binex.ui.api.cao.subprocess.Popen", return_value=proc),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        resp = await client.post("/api/v1/cao/server/start")
+
+    assert resp.status_code == 500
+    assert resp.json() == {"error": "CAO server failed to start"}
+    assert cao_api._cao_process is None
+
+
+@pytest.mark.asyncio
+async def test_server_stop_not_managed(client):
+    resp = await client.post("/api/v1/cao/server/stop")
+
+    assert resp.json() == {"status": "not_managed"}
+
+
+@pytest.mark.asyncio
+async def test_server_stop_sends_sigint(client):
+    proc = _mock_proc(pid=9004)
+    cao_api._cao_process = proc
+
+    resp = await client.post("/api/v1/cao/server/stop")
+
+    assert resp.json() == {"status": "stopped", "pid": 9004}
+    proc.send_signal.assert_called_once_with(signal.SIGINT)
+    proc.wait.assert_called_once_with(timeout=10)
+    assert cao_api._cao_process is None
+
+
+# ---------------------------------------------------------------------------
+# GET /cao/profiles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profiles_missing_store_dir_warns(client, tmp_path):
+    resp = await client.get("/api/v1/cao/profiles")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["profiles"] == []
+    assert "not found" in data["warning"]
+
+
+@pytest.mark.asyncio
+async def test_profiles_lists_md_stems_sorted(client, tmp_path):
+    store_dir = tmp_path / "agent-store"
+    store_dir.mkdir()
+    (store_dir / "reviewer.md").write_text("# reviewer")
+    (store_dir / "architect.md").write_text("# architect")
+    (store_dir / "notes.txt").write_text("ignored")
+
+    resp = await client.get("/api/v1/cao/profiles")
+
+    data = resp.json()
+    assert data["profiles"] == ["architect", "reviewer"]
+    assert "warning" not in data
+
+
+# ---------------------------------------------------------------------------
+# GET /cao/sessions, DELETE /cao/sessions/{terminal_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sessions(client):
+    exec_store = InMemoryExecutionStore()
+    await exec_store.create_cao_session("term-1", "run-1", "node-a")
+
+    with patch(
+        "binex.ui.api.cao._get_stores",
+        return_value=(exec_store, InMemoryArtifactStore()),
+    ):
+        resp = await client.get("/api/v1/cao/sessions")
+
+    sessions = resp.json()["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["terminal_id"] == "term-1"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_delete_session_cleans_up_even_if_cao_is_down(client):
+    # Best-effort contract: the CAO server being unreachable must not stop
+    # registry cleanup.
+    respx.post(f"{CAO_URL}/terminals/term-1/exit").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+    respx.delete(f"{CAO_URL}/terminals/term-1").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+    exec_store = InMemoryExecutionStore()
+    await exec_store.create_cao_session("term-1", "run-1", "node-a")
+
+    with patch(
+        "binex.ui.api.cao._get_stores",
+        return_value=(exec_store, InMemoryArtifactStore()),
+    ):
+        resp = await client.delete("/api/v1/cao/sessions/term-1")
+
+    assert resp.json() == {"ok": True}
+    assert await exec_store.get_cao_sessions() == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_delete_unknown_session_returns_404(client):
+    respx.post(f"{CAO_URL}/terminals/ghost/exit").mock(
+        return_value=httpx.Response(200)
+    )
+    respx.delete(f"{CAO_URL}/terminals/ghost").mock(
+        return_value=httpx.Response(200)
+    )
+
+    with patch(
+        "binex.ui.api.cao._get_stores",
+        return_value=(InMemoryExecutionStore(), InMemoryArtifactStore()),
+    ):
+        resp = await client.delete("/api/v1/cao/sessions/ghost")
+
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "session not found"}
+
+
+# ---------------------------------------------------------------------------
+# POST /cao/terminals/{terminal_id}/input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_terminal_input_forwarded(client):
+    route = respx.post(f"{CAO_URL}/terminals/term-1/input").mock(
+        return_value=httpx.Response(200)
+    )
+
+    resp = await client.post(
+        "/api/v1/cao/terminals/term-1/input", json={"message": "yes, proceed"}
+    )
+
+    assert resp.json() == {"ok": True}
+    assert route.calls.last.request.url.params["message"] == "yes, proceed"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_terminal_input_cao_down_returns_502(client):
+    respx.post(f"{CAO_URL}/terminals/term-1/input").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    resp = await client.post(
+        "/api/v1/cao/terminals/term-1/input", json={"message": "hello"}
+    )
+
+    assert resp.status_code == 502
+    assert "CAO server error" in resp.json()["error"]

--- a/tests/unit/ui_api/test_ui_api_gateway.py
+++ b/tests/unit/ui_api/test_ui_api_gateway.py
@@ -1,0 +1,99 @@
+"""Tests for the gateway API endpoints (subprocess start/stop/process-status)."""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import binex.ui.api.gateway as gateway_api
+
+
+@pytest.fixture(autouse=True)
+def _reset_gateway_process():
+    gateway_api._gateway_process = None
+    yield
+    gateway_api._gateway_process = None
+
+
+def _mock_proc(pid: int = 8421, alive: bool = True) -> MagicMock:
+    # spec=Popen catches typo'd method names; pid is an instance attribute
+    # (absent from the class spec) and must be assigned explicitly.
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = pid
+    proc.poll.return_value = None if alive else 0
+    proc.wait.return_value = 0
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_process_status_not_running(client):
+    resp = await client.get("/api/v1/gateway/process-status")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"running": False, "pid": None}
+
+
+@pytest.mark.asyncio
+async def test_process_status_running(client):
+    gateway_api._gateway_process = _mock_proc(pid=8421)
+
+    resp = await client.get("/api/v1/gateway/process-status")
+
+    assert resp.json() == {"running": True, "pid": 8421}
+
+
+@pytest.mark.asyncio
+async def test_start_spawns_subprocess_with_options(client):
+    proc = _mock_proc(pid=321)
+    with patch(
+        "binex.ui.api.gateway.subprocess.Popen", return_value=proc
+    ) as popen:
+        resp = await client.post(
+            "/api/v1/gateway/start",
+            json={"config": "gw.yaml", "host": "0.0.0.0", "port": 9000},
+        )
+
+    assert resp.json() == {"status": "started", "pid": 321}
+    assert popen.call_args[0][0] == [
+        sys.executable, "-m", "binex", "gateway",
+        "--config", "gw.yaml", "--host", "0.0.0.0", "--port", "9000",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_twice_reports_already_running(client):
+    proc = _mock_proc(pid=321)
+    with patch(
+        "binex.ui.api.gateway.subprocess.Popen", return_value=proc
+    ) as popen:
+        first = await client.post("/api/v1/gateway/start", json={})
+        second = await client.post("/api/v1/gateway/start", json={})
+
+    assert first.json()["status"] == "started"
+    assert second.json() == {"status": "already_running", "pid": 321}
+    assert popen.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_without_running_gateway(client):
+    resp = await client.post("/api/v1/gateway/stop")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "not_running"}
+
+
+@pytest.mark.asyncio
+async def test_stop_sends_sigint_and_waits(client):
+    proc = _mock_proc(pid=654)
+    gateway_api._gateway_process = proc
+
+    resp = await client.post("/api/v1/gateway/stop")
+
+    assert resp.json() == {"status": "stopped", "pid": 654}
+    proc.send_signal.assert_called_once_with(signal.SIGINT)
+    proc.wait.assert_called_once_with(timeout=30)
+    assert gateway_api._gateway_process is None

--- a/tests/unit/ui_api/test_ui_api_scheduler.py
+++ b/tests/unit/ui_api/test_ui_api_scheduler.py
@@ -1,0 +1,227 @@
+"""Tests for the scheduler API endpoints (status, history, start/stop, add/remove)."""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import binex.ui.api.scheduler as scheduler_api
+from binex.scheduler.models import HistoryEntry, ScheduledWorkflow, SchedulerState
+from binex.scheduler.state import load_state, save_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_scheduler_process():
+    # _scheduler_process is module-global mutable state; without a reset a
+    # mock left behind by one test leaks "already_running" into the next.
+    scheduler_api._scheduler_process = None
+    yield
+    scheduler_api._scheduler_process = None
+
+
+@pytest.fixture
+def state_path(tmp_path):
+    path = tmp_path / "scheduler.json"
+    with patch("binex.ui.api.scheduler._get_state_path", return_value=path):
+        yield path
+
+
+def _mock_proc(pid: int = 4242, alive: bool = True) -> MagicMock:
+    # spec=Popen so a typo'd method name raises instead of being silently
+    # swallowed; pid is an instance attribute (absent from the class spec)
+    # and must be assigned explicitly.
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = pid
+    proc.poll.return_value = None if alive else 0
+    proc.wait.return_value = 0
+    return proc
+
+
+def _entry(workflow: str, day: int) -> HistoryEntry:
+    return HistoryEntry(
+        workflow=workflow,
+        timestamp=datetime(2026, 1, day, tzinfo=UTC),
+        run_id=f"sched-{workflow}-{day}",
+        status="completed",
+        duration_s=1.5,
+        cost=0.01,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /scheduler/status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_not_running(client, state_path):
+    save_state(SchedulerState(registered=["/tmp/a.yaml"]), state_path)
+    wf = ScheduledWorkflow(
+        name="nightly",
+        path="/tmp/a.yaml",
+        schedule="0 2 * * *",
+        next_run=datetime(2026, 1, 2, 2, 0, tzinfo=UTC),
+    )
+    with patch("binex.ui.api.scheduler.scan_directory", return_value=[wf]):
+        resp = await client.get("/api/v1/scheduler/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["running"] is False
+    assert data["pid"] is None
+    assert data["registered_count"] == 1
+    assert data["workflows"] == [
+        {
+            "name": "nightly",
+            "path": "/tmp/a.yaml",
+            "schedule": "0 2 * * *",
+            "next_run": "2026-01-02T02:00:00+00:00",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_status_running(client, state_path):
+    scheduler_api._scheduler_process = _mock_proc(pid=4242)
+    with patch("binex.ui.api.scheduler.scan_directory", return_value=[]):
+        resp = await client.get("/api/v1/scheduler/status")
+
+    data = resp.json()
+    assert data["running"] is True
+    assert data["pid"] == 4242
+
+
+# ---------------------------------------------------------------------------
+# /scheduler/history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_history_limit_returns_newest_first(client, state_path):
+    state = SchedulerState()
+    for day in (1, 2, 3):
+        state.add_history(_entry("wf", day))
+    save_state(state, state_path)
+
+    resp = await client.get("/api/v1/scheduler/history", params={"limit": 2})
+
+    assert resp.status_code == 200
+    history = resp.json()["history"]
+    assert [e["run_id"] for e in history] == ["sched-wf-3", "sched-wf-2"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, 1001])
+async def test_history_invalid_limit_rejected(client, state_path, limit):
+    resp = await client.get("/api/v1/scheduler/history", params={"limit": limit})
+
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /scheduler/start, /scheduler/stop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_spawns_subprocess(client, state_path):
+    # Build the proc mock before patching: once Popen is patched,
+    # spec=subprocess.Popen would spec against the mock (InvalidSpecError).
+    proc = _mock_proc(pid=555)
+    with patch("binex.ui.api.scheduler.subprocess.Popen", return_value=proc) as popen:
+        resp = await client.post("/api/v1/scheduler/start", json={"directory": "."})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "started", "pid": 555}
+    assert popen.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_start_twice_reports_already_running(client, state_path):
+    proc = _mock_proc(pid=555)
+    with patch("binex.ui.api.scheduler.subprocess.Popen", return_value=proc) as popen:
+        first = await client.post("/api/v1/scheduler/start", json={"directory": "."})
+        second = await client.post("/api/v1/scheduler/start", json={"directory": "."})
+
+    assert first.json()["status"] == "started"
+    assert second.json() == {"status": "already_running", "pid": 555}
+    assert popen.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_without_running_scheduler(client, state_path):
+    resp = await client.post("/api/v1/scheduler/stop")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "not_running"}
+
+
+@pytest.mark.asyncio
+async def test_stop_sends_sigint_and_waits(client, state_path):
+    proc = _mock_proc(pid=777)
+    scheduler_api._scheduler_process = proc
+
+    resp = await client.post("/api/v1/scheduler/stop")
+
+    assert resp.json() == {"status": "stopped", "pid": 777}
+    proc.send_signal.assert_called_once_with(signal.SIGINT)
+    proc.wait.assert_called_once_with(timeout=30)
+    assert scheduler_api._scheduler_process is None
+
+
+# ---------------------------------------------------------------------------
+# /scheduler/add, /scheduler/remove
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_registers_workflow(client, state_path, tmp_path):
+    wf_path = tmp_path / "wf.yaml"
+
+    resp = await client.post(
+        "/api/v1/scheduler/add", json={"workflow_path": str(wf_path)}
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "registered", "path": str(wf_path.resolve())}
+    assert load_state(state_path).registered == [str(wf_path.resolve())]
+
+
+@pytest.mark.asyncio
+async def test_add_is_idempotent(client, state_path, tmp_path):
+    wf_path = str(tmp_path / "wf.yaml")
+
+    await client.post("/api/v1/scheduler/add", json={"workflow_path": wf_path})
+    await client.post("/api/v1/scheduler/add", json={"workflow_path": wf_path})
+
+    assert load_state(state_path).registered == [str(Path(wf_path).resolve())]
+
+
+@pytest.mark.asyncio
+async def test_remove_registered_workflow(client, state_path, tmp_path):
+    wf_path = str((tmp_path / "wf.yaml").resolve())
+    save_state(SchedulerState(registered=[wf_path]), state_path)
+
+    resp = await client.post(
+        "/api/v1/scheduler/remove", json={"workflow_path": wf_path}
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "removed", "path": wf_path}
+    assert load_state(state_path).registered == []
+
+
+@pytest.mark.asyncio
+async def test_remove_unknown_workflow_returns_404(client, state_path, tmp_path):
+    resp = await client.post(
+        "/api/v1/scheduler/remove",
+        json={"workflow_path": str(tmp_path / "ghost.yaml")},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["status"] == "not_found"

--- a/tests/unit/ui_api/test_ui_api_system.py
+++ b/tests/unit/ui_api/test_ui_api_system.py
@@ -1,0 +1,155 @@
+"""Tests for the system API endpoints (doctor, plugins, gateway)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+
+def _check_by_name(checks: list[dict], name: str) -> dict:
+    matches = [c for c in checks if c["name"] == name]
+    assert matches, f"check {name!r} missing from {[c['name'] for c in checks]}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# /system/doctor
+# ---------------------------------------------------------------------------
+
+# Environment-dependent checks (Artifact Store looks at the local .binex/
+# directory) are asserted shape-only — the machine running the suite owes
+# the test nothing about its disk. Store connectivity is made
+# deterministic by patching get_stores; Python Version is deterministic
+# because the suite itself requires 3.11+.
+
+
+@pytest.mark.asyncio
+async def test_doctor_returns_all_checks_with_valid_shape(client):
+    stores = (InMemoryExecutionStore(), InMemoryArtifactStore())
+    with patch("binex.cli.get_stores", return_value=stores):
+        resp = await client.get("/api/v1/system/doctor")
+
+    assert resp.status_code == 200
+    checks = resp.json()["checks"]
+    assert {c["name"] for c in checks} == {
+        "Python Version",
+        "SQLite Store",
+        "Artifact Store",
+        "LiteLLM",
+    }
+    for check in checks:
+        assert check["status"] in ("ok", "warn", "error")
+        assert check["message"]
+
+    assert _check_by_name(checks, "Python Version")["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_doctor_store_connected(client):
+    stores = (InMemoryExecutionStore(), InMemoryArtifactStore())
+    with patch("binex.cli.get_stores", return_value=stores):
+        resp = await client.get("/api/v1/system/doctor")
+
+    check = _check_by_name(resp.json()["checks"], "SQLite Store")
+    assert check["status"] == "ok"
+    assert check["message"] == "Connected"
+
+
+@pytest.mark.asyncio
+async def test_doctor_reports_store_failure_without_crashing(client):
+    with patch("binex.cli.get_stores", side_effect=RuntimeError("db locked")):
+        resp = await client.get("/api/v1/system/doctor")
+
+    assert resp.status_code == 200
+    check = _check_by_name(resp.json()["checks"], "SQLite Store")
+    assert check["status"] == "error"
+    assert "db locked" in check["message"]
+
+
+# ---------------------------------------------------------------------------
+# /system/plugins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plugins_lists_builtin_adapters(client):
+    resp = await client.get("/api/v1/system/plugins")
+
+    assert resp.status_code == 200
+    plugins = resp.json()["plugins"]
+    builtins = {p["name"] for p in plugins if p["builtin"]}
+    assert builtins == {"local", "llm", "human", "a2a"}
+
+
+@pytest.mark.asyncio
+async def test_plugins_discovery_failure_is_best_effort(client):
+    with patch(
+        "binex.plugins.PluginRegistry",
+        side_effect=RuntimeError("entry points broken"),
+    ):
+        resp = await client.get("/api/v1/system/plugins")
+
+    assert resp.status_code == 200
+    builtins = {p["name"] for p in resp.json()["plugins"] if p["builtin"]}
+    assert builtins == {"local", "llm", "human", "a2a"}
+
+
+# ---------------------------------------------------------------------------
+# /system/gateway
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_gateway_online_reports_agents(client):
+    route = respx.get("http://localhost:8421/health").mock(
+        return_value=httpx.Response(
+            200, json={"agents": [{"name": "researcher"}, {"name": "writer"}]}
+        )
+    )
+
+    resp = await client.get("/api/v1/system/gateway")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "online"
+    assert len(data["agents"]) == 2
+    assert data["message"] == "Gateway running, 2 agent(s) registered"
+    assert route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_gateway_upstream_error_status(client):
+    respx.get("http://localhost:8421/health").mock(
+        return_value=httpx.Response(500)
+    )
+
+    resp = await client.get("/api/v1/system/gateway")
+
+    data = resp.json()
+    assert data["status"] == "error"
+    assert data["agents"] == []
+    assert "500" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_offline_returns_structured_response(client):
+    # No mocks: point the endpoint at a port nothing listens on and let
+    # the connection genuinely fail. A dead dependency must produce a
+    # structured "offline" answer, not a 500.
+    with patch(
+        "binex.ui.api.system._DEFAULT_GATEWAY_URL", "http://127.0.0.1:59999"
+    ):
+        resp = await client.get("/api/v1/system/gateway")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "offline"
+    assert data["agents"] == []
+    assert data["message"]

--- a/tests/unit/ui_api/test_ui_api_tools.py
+++ b/tests/unit/ui_api/test_ui_api_tools.py
@@ -1,0 +1,47 @@
+"""Tests for the built-in tools API endpoint."""
+
+from __future__ import annotations
+
+import pytest
+
+# The public contract: 10 built-in tools, documented in CLAUDE.md and
+# docs/. A hard equality is deliberate — adding/removing a tool must
+# break this test so the docs and the _CATEGORIES map in
+# binex/ui/api/tools.py get updated in the same change.
+EXPECTED_TOOLS = {
+    "calculator",
+    "dice_roll",
+    "fetch_url",
+    "http_request",
+    "web_search",
+    "read_file",
+    "write_file",
+    "shell_command",
+    "json_parse",
+    "random_choice",
+}
+
+# "other" is the endpoint's fallback for tools missing from _CATEGORIES;
+# excluded on purpose — every builtin must be explicitly categorized.
+ALLOWED_CATEGORIES = {"data", "web", "files", "system"}
+
+
+@pytest.mark.asyncio
+async def test_list_builtin_tools_matches_documented_set(client):
+    resp = await client.get("/api/v1/tools/builtins")
+
+    assert resp.status_code == 200
+    tools = resp.json()["tools"]
+    assert {t["name"] for t in tools} == EXPECTED_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_builtin_tools_shape_and_categories(client):
+    resp = await client.get("/api/v1/tools/builtins")
+
+    assert resp.status_code == 200
+    for tool in resp.json()["tools"]:
+        assert tool["name"]
+        assert tool["description"]
+        assert tool["category"] in ALLOWED_CATEGORIES
+        assert isinstance(tool["parameters"], dict)


### PR DESCRIPTION
## Summary

**Merge order: 2 of 3** — based on `refactor/split-unit-tests` (new tests rely on its `ui_api/conftest.py`); retargets to master automatically once that merges.

46 new tests across five files closing the last untested UI routers:

- **tools** (2): builtin list pinned to the documented 10-tool contract (a new tool must update docs + `_CATEGORIES` in the same change); categories from the allowed set, `other` fallback deliberately rejected.
- **system** (8): doctor with patched stores (connected + failure path), shape-only asserts for environment-dependent checks; plugins best-effort discovery; gateway online/error/offline via respx.
- **scheduler** (13) & **gateway** (6): subprocess lifecycle with `spec=subprocess.Popen` mocks — start twice → single Popen call, stop without process, SIGINT + `wait(timeout=…)`, history limit validation (0/1001 → 422), state isolated via `tmp_path`.
- **cao** (17): health online/degraded/offline, server lifecycle (4 start branches), profiles from filesystem, session cleanup **with CAO server down** (best-effort contract), HITL input forwarding → 502 on ConnectError. Server URL pointed at a fake host via env so no test can ever reach a real `localhost:9889`.

`respx` added to dev dependencies: outgoing httpx traffic is intercepted at the transport layer; an unmocked request fails the test instead of hitting the network.

## Test plan

- [x] `pytest tests/unit/ui_api` — 322 passed
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)