### PR TITLE
test: close phase-1 coverage tails — export csv/zip, collector finalisation

### DIFF
--- a/tests/unit/importers/test_otel_collector.py
+++ b/tests/unit/importers/test_otel_collector.py
@@ -6,6 +6,7 @@ Uses httpx AsyncClient against the FastAPI app directly (no real port needed).
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -371,3 +372,100 @@ class TestMultipleTraces:
         data = health.json()
         # Two distinct trace IDs → two separate buffers
         assert data["pending_traces"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Finalisation (background watcher)
+#
+# httpx.ASGITransport does not run ASGI lifespan, so the `_watch_buffers`
+# task never starts in the tests above — we enter the app's lifespan
+# context manually here.
+#
+# Conscious testing boundaries: the protobuf decode success/parse-error
+# paths require `opentelemetry-proto` (the `telemetry` extra), absent in
+# the test environment — only the 415 gate is covered.
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for_run(exec_store, timeout: float = 3.0):
+    """Poll the store until the finaliser has written a run."""
+    async def poll():
+        while True:
+            runs = await exec_store.list_runs()
+            if runs:
+                return runs
+            await asyncio.sleep(0.02)
+
+    return await asyncio.wait_for(poll(), timeout=timeout)
+
+
+class TestFinalisation:
+    @pytest.mark.asyncio
+    async def test_quiet_period_finalises_into_store(self):
+        """Root span + quiet period → converted run lands in the store."""
+        from httpx import ASGITransport, AsyncClient
+
+        exec_store = InMemoryExecutionStore()
+        art_store = InMemoryArtifactStore()
+        app = _make_app(exec_store, art_store, quiet_period=0.05)
+
+        payload = _load_fixture("langchain-openllmetry.json")
+
+        async with app.router.lifespan_context(app):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                await client.post("/v1/traces", json=payload)
+                runs = await _wait_for_run(exec_store)
+
+        assert len(runs) == 1
+        assert runs[0].source == "otel-import"
+        assert runs[0].status != "partial"
+        records = await exec_store.list_records(runs[0].run_id)
+        assert len(records) == 2  # both fixture spans converted
+
+    @pytest.mark.asyncio
+    async def test_hard_timeout_finalises_partial(self):
+        """No quiet finalisation possible → hard timeout forces 'partial'."""
+        from httpx import ASGITransport, AsyncClient
+
+        exec_store = InMemoryExecutionStore()
+        art_store = InMemoryArtifactStore()
+        # quiet_period effectively unreachable; hard timeout fires first
+        app = _make_app(
+            exec_store, art_store, quiet_period=9999.0, hard_timeout=0.15,
+        )
+
+        payload = _load_fixture("langchain-openllmetry.json")
+
+        async with app.router.lifespan_context(app):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                await client.post("/v1/traces", json=payload)
+                runs = await _wait_for_run(exec_store)
+
+        assert runs[0].status == "partial"
+        assert runs[0].source == "otel-collector-partial"
+
+    @pytest.mark.asyncio
+    async def test_finalised_trace_reflected_in_health(self):
+        from httpx import ASGITransport, AsyncClient
+
+        exec_store = InMemoryExecutionStore()
+        art_store = InMemoryArtifactStore()
+        app = _make_app(exec_store, art_store, quiet_period=0.05)
+
+        payload = _load_fixture("langchain-openllmetry.json")
+
+        async with app.router.lifespan_context(app):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                await client.post("/v1/traces", json=payload)
+                await _wait_for_run(exec_store)
+                health = await client.get("/health")
+
+        data = health.json()
+        assert data["finalized_traces"] == 1
+        assert data["pending_traces"] == 0

--- a/tests/unit/ui_api/test_ui_api_export.py
+++ b/tests/unit/ui_api/test_ui_api_export.py
@@ -1,13 +1,18 @@
-"""Tests for the export API endpoint (run_ids and last_n modes)."""
+"""Tests for the export API endpoint (run_ids/last_n modes, JSON and CSV/zip)."""
 
 from __future__ import annotations
 
+import io
+import zipfile
 from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
 
-from binex.models.execution import RunSummary
+from binex.models.artifact import Artifact, Lineage
+from binex.models.cost import CostRecord
+from binex.models.execution import ExecutionRecord, RunSummary
+from binex.models.task import TaskStatus
 
 
 def _make_run(run_id: str = "run-1", **kwargs) -> RunSummary:
@@ -25,6 +30,41 @@ def _make_run(run_id: str = "run-1", **kwargs) -> RunSummary:
 
 def _patch_stores(stores):
     return patch("binex.ui.api.export._get_stores", return_value=stores)
+
+
+async def _seed_full_run(stores, run_id: str = "run-full") -> None:
+    """Run with one record, one cost record, and one artifact."""
+    exec_store, art_store = stores
+    await exec_store.create_run(_make_run(run_id))
+    await exec_store.record(
+        ExecutionRecord(
+            id=f"rec-{run_id}",
+            run_id=run_id,
+            task_id="node-a",
+            agent_id="local://echo",
+            status=TaskStatus.COMPLETED,
+            latency_ms=7,
+            trace_id=f"trace-{run_id}",
+        )
+    )
+    await exec_store.record_cost(
+        CostRecord(
+            id=f"cost-{run_id}",
+            run_id=run_id,
+            task_id="node-a",
+            cost=0.01,
+            source="llm_tokens",
+        )
+    )
+    await art_store.store(
+        Artifact(
+            id=f"art-{run_id}",
+            run_id=run_id,
+            type="text",
+            content="payload",
+            lineage=Lineage(produced_by="node-a"),
+        )
+    )
 
 
 @pytest.mark.asyncio
@@ -127,3 +167,100 @@ async def test_export_empty_run_ids_rejected(client, stores):
 
     assert resp.status_code == 422
     assert resp.json()["error"] == "run_ids must not be empty"
+
+
+@pytest.mark.asyncio
+async def test_export_unsupported_format_rejected(client, stores):
+    with _patch_stores(stores):
+        resp = await client.post(
+            "/api/v1/export", json={"run_ids": ["run-1"], "format": "xml"}
+        )
+
+    assert resp.status_code == 422
+    assert "Unsupported format: xml" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_export_mixed_found_and_missing_exports_found_only(client, stores):
+    exec_store, _ = stores
+    await exec_store.create_run(_make_run("run-real"))
+
+    with _patch_stores(stores):
+        resp = await client.post(
+            "/api/v1/export",
+            json={"run_ids": ["run-real", "run-ghost"], "format": "json"},
+        )
+
+    assert resp.status_code == 200
+    assert [r["run_id"] for r in resp.json()["runs"]] == ["run-real"]
+
+
+@pytest.mark.asyncio
+async def test_export_json_include_artifacts(client, stores):
+    await _seed_full_run(stores, "run-art")
+
+    with _patch_stores(stores):
+        resp = await client.post(
+            "/api/v1/export",
+            json={"run_ids": ["run-art"], "format": "json", "include_artifacts": True},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [a["id"] for a in data["artifacts"]] == ["art-run-art"]
+    assert data["artifacts"][0]["content"] == "payload"
+
+
+@pytest.mark.asyncio
+async def test_export_csv_returns_zip_with_three_csvs(client, stores):
+    await _seed_full_run(stores, "run-csv")
+
+    with _patch_stores(stores):
+        resp = await client.post(
+            "/api/v1/export", json={"run_ids": ["run-csv"], "format": "csv"}
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+    assert "binex-export.zip" in resp.headers["content-disposition"]
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    assert set(zf.namelist()) == {"runs.csv", "records.csv", "costs.csv"}
+    runs_csv = zf.read("runs.csv").decode().splitlines()
+    assert runs_csv[0].startswith("run_id,")  # header row
+    assert runs_csv[1].startswith("run-csv,")
+    assert "node-a" in zf.read("records.csv").decode()
+    assert "cost-run-csv" in zf.read("costs.csv").decode()
+
+
+@pytest.mark.asyncio
+async def test_export_csv_include_artifacts_adds_artifacts_json(client, stores):
+    await _seed_full_run(stores, "run-zip-art")
+
+    with _patch_stores(stores):
+        resp = await client.post(
+            "/api/v1/export",
+            json={"run_ids": ["run-zip-art"], "format": "csv", "include_artifacts": True},
+        )
+
+    assert resp.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    assert "artifacts.json" in zf.namelist()
+    assert "art-run-zip-art" in zf.read("artifacts.json").decode()
+
+
+@pytest.mark.asyncio
+async def test_export_csv_run_without_costs_yields_empty_costs_csv(client, stores):
+    exec_store, _ = stores
+    await exec_store.create_run(_make_run("run-bare"))
+
+    with _patch_stores(stores):
+        resp = await client.post(
+            "/api/v1/export", json={"run_ids": ["run-bare"], "format": "csv"}
+        )
+
+    assert resp.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    # _write_csv returns "" for an empty row list — member exists but is empty
+    assert zf.read("costs.csv") == b""
+    assert zf.read("records.csv") == b""


### PR DESCRIPTION
## What

- **`ui/api/export.py` 72% → 99%** — csv/zip branch (archive members `runs.csv`/`records.csv`/`costs.csv`, `artifacts.json` under `include_artifacts`), json+artifacts, unsupported-format 422, mixed found/missing run_ids, empty-rows csv.
- **`importers/collector.py` 53% → 89%** — quiet-period and hard-timeout (`partial`) finalisation. Root cause of the 0% watcher: `httpx.ASGITransport` never runs ASGI lifespan, so `_watch_buffers` never started in tests — fixed by entering `app.router.lifespan_context` manually.

## Conscious boundaries (in words)

- collector protobuf decode paths — require `opentelemetry-proto` (absent in the test env); the 415 gate is covered
- `cli/collect.py` — a uvicorn launcher; patching `uvicorn.run` would only assert the wrapper calls uvicorn (a test for the percent, not the behavior)

## Verification

```
3144 passed, 2 skipped in 43.81s
All checks passed! (ruff)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)