### PR TITLE
test: cover phase-3 worklist (resume, parser, judge, subtask tree, diff_rich, scheduler)

### DIFF
--- a/tests/unit/cli/test_resume_cmd.py
+++ b/tests/unit/cli/test_resume_cmd.py
@@ -1,0 +1,133 @@
+"""Tests for the `binex resume` CLI command (cli/resume.py).
+
+The ResumeEngine itself is covered in tests/unit/runtime/test_resume.py;
+here we pin the CLI layer: store guards, output formats, exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+
+from binex.cli.resume import resume_cmd
+from binex.models.execution import RunSummary
+from binex.runtime.resume import ResumeResult
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+
+def _summary(**kwargs) -> RunSummary:
+    defaults = dict(
+        run_id="run-child",
+        workflow_name="wf",
+        status="completed",
+        total_nodes=3,
+        completed_nodes=3,
+        resumed_from="run-parent",
+    )
+    defaults.update(kwargs)
+    return RunSummary(**defaults)
+
+
+def _result(**kwargs) -> ResumeResult:
+    defaults = dict(summary=_summary(), resumed_nodes=1, cached_nodes=2, warnings=[])
+    defaults.update(kwargs)
+    return ResumeResult(**defaults)
+
+
+def _patch_run_resume(result=None, error=None):
+    mock = AsyncMock(return_value=result)
+    if error is not None:
+        mock.side_effect = error
+    return patch("binex.cli.resume._run_resume", mock)
+
+
+# ---------------------------------------------------------------------------
+# Store guards (real _run_resume against in-memory stores)
+# ---------------------------------------------------------------------------
+
+
+def test_resume_unknown_run_exits_1_with_error():
+    stores = (InMemoryExecutionStore(), InMemoryArtifactStore())
+
+    with patch("binex.cli.resume.get_stores", return_value=stores):
+        result = CliRunner().invoke(resume_cmd, ["run-ghost"])
+
+    assert result.exit_code == 1
+    assert "Run 'run-ghost' not found" in result.output
+
+
+def test_resume_run_without_workflow_path_exits_1():
+    exec_store = InMemoryExecutionStore()
+    stores = (exec_store, InMemoryArtifactStore())
+    import asyncio
+
+    asyncio.run(exec_store.create_run(
+        _summary(run_id="run-nopath", workflow_path=None, status="failed")
+    ))
+
+    with patch("binex.cli.resume.get_stores", return_value=stores):
+        result = CliRunner().invoke(resume_cmd, ["run-nopath"])
+
+    assert result.exit_code == 1
+    assert "no recorded workflow_path" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Presentation layer (mocked _run_resume)
+# ---------------------------------------------------------------------------
+
+
+def test_resume_text_output_and_exit_0_on_completed():
+    with _patch_run_resume(_result()):
+        result = CliRunner().invoke(resume_cmd, ["run-parent"])
+
+    assert result.exit_code == 0
+    assert "Resume Run ID: run-child" in result.output
+    assert "Resumed from: run-parent" in result.output
+    assert "Nodes: 3/3 completed (2 cached, 1 re-run)" in result.output
+
+
+def test_resume_failed_status_exits_1():
+    with _patch_run_resume(
+        _result(summary=_summary(status="failed", completed_nodes=2, failed_nodes=1))
+    ):
+        result = CliRunner().invoke(resume_cmd, ["run-parent"])
+
+    assert result.exit_code == 1
+    assert "Failed: 1" in result.output
+
+
+def test_resume_json_output_includes_node_counts():
+    with _patch_run_resume(_result()):
+        result = CliRunner().invoke(resume_cmd, ["run-parent", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["run_id"] == "run-child"
+    assert data["resumed_nodes"] == 1
+    assert data["cached_nodes"] == 2
+
+
+def test_resume_prints_warnings_with_marker():
+    with _patch_run_resume(_result(warnings=["topology drift detected"])):
+        result = CliRunner().invoke(resume_cmd, ["run-parent"])
+
+    assert "⚠ topology drift detected" in result.output
+
+
+def test_resume_cost_line_only_when_positive():
+    with _patch_run_resume(_result(summary=_summary(total_cost=0.1234))):
+        result = CliRunner().invoke(resume_cmd, ["run-parent"])
+
+    assert "Cost (cumulative): $0.1234" in result.output
+
+
+def test_resume_forwards_from_and_force_flags():
+    mock = AsyncMock(return_value=_result())
+
+    with patch("binex.cli.resume._run_resume", mock):
+        CliRunner().invoke(resume_cmd, ["run-parent", "--from", "step3", "--force"])
+
+    mock.assert_awaited_once_with("run-parent", "step3", True)

--- a/tests/unit/cli/test_trace_subtask_tree.py
+++ b/tests/unit/cli/test_trace_subtask_tree.py
@@ -1,0 +1,122 @@
+"""Tests for render_subtask_tree() and `binex trace subtasks` (cli/trace.py).
+
+The grouping/rendering logic is pure (events in, string out) — only the
+rich panel styling elsewhere in cli/trace.py is a conscious boundary.
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from binex.cli.trace import render_subtask_tree, trace_subtasks_cmd
+
+
+def _start(name: str) -> dict:
+    return {"type": "task_start", "name": name}
+
+
+def _end(name: str, status: str = "ok", duration: float = 1.5, error: str | None = None) -> dict:
+    ev = {"type": "task_end", "name": name, "status": status, "duration_s": duration}
+    if error:
+        ev["error"] = error
+    return ev
+
+
+def test_empty_events_placeholder():
+    assert render_subtask_tree([]) == "(no trace events)"
+
+
+def test_completed_task_shows_check_and_duration():
+    tree = render_subtask_tree([_start("fetch"), _end("fetch", duration=3.1)])
+
+    assert "fetch" in tree
+    assert "✅ 3.1s" in tree
+
+
+def test_failed_task_shows_error_and_duration():
+    tree = render_subtask_tree(
+        [_start("parse"), _end("parse", status="error", duration=30.0, error="boom")]
+    )
+
+    assert "❌ boom (30.0s)" in tree
+
+
+def test_task_without_end_marked_not_reached():
+    tree = render_subtask_tree([_start("late")])
+
+    assert "⏸ not reached" in tree
+
+
+def test_children_attach_to_current_task():
+    events = [
+        _start("work"),
+        {"type": "log", "message": "step one"},
+        {"type": "checkpoint", "label": "half-way"},
+        _end("work"),
+    ]
+
+    tree = render_subtask_tree(events)
+
+    assert 'log: "step one"' in tree
+    assert 'checkpoint: "half-way"' in tree
+
+
+def test_orphan_children_before_first_task_ignored():
+    events = [{"type": "log", "message": "orphan"}, _start("a"), _end("a")]
+
+    tree = render_subtask_tree(events)
+
+    assert "orphan" not in tree
+
+
+def test_task_end_matched_by_name_only():
+    # end for a different name must not close the current task
+    events = [_start("a"), _end("b"), _start("c"), _end("c")]
+
+    tree = render_subtask_tree(events)
+
+    assert "⏸ not reached" in tree  # task "a" never ended
+    assert "✅" in tree  # task "c" did
+
+
+def test_tree_connectors_last_vs_middle():
+    events = [_start("first"), _end("first"), _start("second"), _end("second")]
+
+    lines = render_subtask_tree(events).splitlines()
+
+    assert lines[0].startswith("├─")
+    assert lines[1].startswith("└─")
+
+
+# ---------------------------------------------------------------------------
+# binex trace subtasks (file → parse → render)
+# ---------------------------------------------------------------------------
+
+
+def test_subtasks_command_renders_from_stderr_file(tmp_path):
+    stderr_file = tmp_path / "stderr.log"
+    events = [
+        {"_binex_trace": True, "type": "task_start", "name": "fetch"},
+        {"_binex_trace": True, "type": "task_end", "name": "fetch",
+         "status": "ok", "duration_s": 2.0},
+    ]
+    stderr_file.write_text(
+        "random noise\n" + "\n".join(json.dumps(e) for e in events) + "\n"
+    )
+
+    result = CliRunner().invoke(trace_subtasks_cmd, [str(stderr_file)])
+
+    assert result.exit_code == 0
+    assert "✅ 2.0s" in result.output
+
+
+def test_subtasks_command_no_events_exits_1(tmp_path):
+    stderr_file = tmp_path / "stderr.log"
+    stderr_file.write_text("no trace here\n")
+
+    result = CliRunner().invoke(trace_subtasks_cmd, [str(stderr_file)])
+
+    assert result.exit_code == 1
+    assert "No binex-trace events found" in result.output

--- a/tests/unit/eval/test_judge_llm_call.py
+++ b/tests/unit/eval/test_judge_llm_call.py
@@ -1,0 +1,100 @@
+"""Tests for the make_judge() LLM-call closure in eval/judge.py.
+
+parse_verdict/resolve_judge_model are covered elsewhere; here we pin the
+async judge itself with a mocked litellm.acompletion — including the
+fail-closed contract: a broken judge must never green-light a regression.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from binex.eval.judge import make_judge
+from binex.models.assertion import Assertion
+
+
+def _llm_reply(text: str) -> dict:
+    return {"choices": [{"message": {"content": text}}]}
+
+
+def _assertion(**kwargs) -> Assertion:
+    defaults = dict(judge="output must mention cats")
+    defaults.update(kwargs)
+    return Assertion(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_pass_reply_parsed():
+    judge = make_judge()
+    mock = AsyncMock(return_value=_llm_reply("PASS: mentions cats"))
+
+    with patch("litellm.acompletion", mock):
+        passed, reason = await judge(_assertion(), "cats are great")
+
+    assert passed is True
+    assert reason == "mentions cats"
+
+
+@pytest.mark.asyncio
+async def test_fail_reply_parsed():
+    judge = make_judge()
+    mock = AsyncMock(return_value=_llm_reply("FAIL: no cats found"))
+
+    with patch("litellm.acompletion", mock):
+        passed, reason = await judge(_assertion(), "dogs only")
+
+    assert passed is False
+    assert reason == "no cats found"
+
+
+@pytest.mark.asyncio
+async def test_llm_exception_fails_closed():
+    judge = make_judge()
+    mock = AsyncMock(side_effect=ConnectionError("api down"))
+
+    with patch("litellm.acompletion", mock):
+        passed, reason = await judge(_assertion(), "anything")
+
+    assert passed is False
+    assert "judge error" in reason
+    assert "api down" in reason
+
+
+@pytest.mark.asyncio
+async def test_empty_reply_fails_closed():
+    judge = make_judge()
+    mock = AsyncMock(return_value=_llm_reply(None))
+
+    with patch("litellm.acompletion", mock):
+        passed, reason = await judge(_assertion(), "anything")
+
+    assert passed is False
+    assert "unparseable" in reason
+
+
+@pytest.mark.asyncio
+async def test_model_resolution_assertion_wins_over_default():
+    judge = make_judge(default_model="default-model")
+    mock = AsyncMock(return_value=_llm_reply("PASS: ok"))
+
+    with patch("litellm.acompletion", mock):
+        await judge(_assertion(judge_model="per-assertion-model"), "text")
+
+    assert mock.await_args.kwargs["model"] == "per-assertion-model"
+
+
+@pytest.mark.asyncio
+async def test_output_truncated_to_max_chars():
+    judge = make_judge()
+    mock = AsyncMock(return_value=_llm_reply("PASS: ok"))
+    long_output = "x" * 10_000
+
+    with patch("litellm.acompletion", mock):
+        await judge(_assertion(judge="rubric text"), long_output)
+
+    user_msg = mock.await_args.kwargs["messages"][1]["content"]
+    assert "rubric text" in user_msg
+    assert "x" * 8000 in user_msg
+    assert "x" * 8001 not in user_msg

--- a/tests/unit/scheduler/test_engine_run_workflow.py
+++ b/tests/unit/scheduler/test_engine_run_workflow.py
@@ -1,0 +1,106 @@
+"""Tests for SchedulerEngine._run_workflow — the actual execution path.
+
+_tick/rescan/skip logic is covered in test_scheduler_engine.py; the start()
+loop (signal handlers + sleep) is a conscious boundary. Here we pin what
+happens when a due workflow actually runs: status mapping, cost recording,
+and the exception contract (a crashing workflow records 'failed' and never
+takes the scheduler down).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from binex.models.execution import RunSummary
+from binex.scheduler.engine import SchedulerEngine
+from binex.scheduler.models import ScheduledWorkflow, SchedulerState
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+
+def _wf(name: str = "wf") -> ScheduledWorkflow:
+    return ScheduledWorkflow(
+        name=name,
+        path="/tmp/wf.yaml",
+        schedule="*/5 * * * *",
+        next_run=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+
+def _engine(wf: ScheduledWorkflow) -> SchedulerEngine:
+    return SchedulerEngine(workflows=[wf], state=SchedulerState())
+
+
+def _summary(status: str, total_cost: float = 0.0) -> RunSummary:
+    return RunSummary(
+        run_id="run-1",
+        workflow_name="wf",
+        status=status,
+        total_nodes=1,
+        completed_nodes=1,
+        total_cost=total_cost,
+    )
+
+
+def _patches(run_result=None, load_error=None):
+    """Patch the function-local imports of _run_workflow."""
+    orchestrator = MagicMock()
+    orchestrator.run_workflow = AsyncMock(return_value=run_result)
+    load = MagicMock(return_value=MagicMock(name="spec"))
+    if load_error is not None:
+        load.side_effect = load_error
+    return (
+        patch("binex.workflow_spec.loader.load_workflow", load),
+        patch(
+            "binex.cli.get_stores",
+            return_value=(InMemoryExecutionStore(), InMemoryArtifactStore()),
+        ),
+        patch(
+            "binex.runtime.orchestrator.Orchestrator",
+            MagicMock(return_value=orchestrator),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_completed_run_recorded_with_cost():
+    wf = _wf()
+    engine = _engine(wf)
+    p_load, p_stores, p_orch = _patches(run_result=_summary("completed", total_cost=0.5))
+
+    with p_load, p_stores, p_orch:
+        await engine._run_workflow(wf)
+
+    entry = engine.state.history[0]
+    assert entry.workflow == "wf"
+    assert entry.status == "completed"
+    assert entry.cost == 0.5
+    assert entry.run_id.startswith("sched-wf-")
+
+
+@pytest.mark.asyncio
+async def test_non_completed_status_mapped_to_failed():
+    wf = _wf()
+    engine = _engine(wf)
+    p_load, p_stores, p_orch = _patches(run_result=_summary("over_budget"))
+
+    with p_load, p_stores, p_orch:
+        await engine._run_workflow(wf)
+
+    assert engine.state.history[0].status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_workflow_exception_recorded_as_failed_not_raised():
+    wf = _wf()
+    engine = _engine(wf)
+    p_load, p_stores, p_orch = _patches(load_error=FileNotFoundError("wf.yaml gone"))
+
+    with p_load, p_stores, p_orch:
+        await engine._run_workflow(wf)  # must not raise
+
+    entry = engine.state.history[0]
+    assert entry.status == "failed"
+    assert entry.cost is None

--- a/tests/unit/trace/test_diff_rich_helpers.py
+++ b/tests/unit/trace/test_diff_rich_helpers.py
@@ -1,0 +1,101 @@
+"""Tests for the pure helpers of trace/diff_rich.py.
+
+The `_render_*` functions (rich Console output) are a conscious boundary —
+see docs/contributing/testing.md; the boundary runs through the terminal,
+not through the file, so the computational helpers are tested here.
+"""
+
+from __future__ import annotations
+
+from binex.trace.diff_rich import (
+    _build_diff_row,
+    _detect_error_changes,
+    _format_latency_delta,
+)
+
+
+def _step(**kwargs) -> dict:
+    defaults = dict(
+        agent_changed=False,
+        agent_a="local://echo",
+        agent_b="local://echo",
+        artifacts_changed=False,
+        status_changed=False,
+        latency_a=100,
+        latency_b=100,
+        status_a="completed",
+        status_b="completed",
+    )
+    defaults.update(kwargs)
+    return defaults
+
+
+class TestFormatLatencyDelta:
+    def test_regression_colored_red_with_plus(self):
+        lat_a, lat_b = _format_latency_delta(100, 250)
+
+        assert lat_a == "100ms"
+        assert lat_b == "250ms [red](+150ms)[/red]"
+
+    def test_improvement_colored_green(self):
+        _, lat_b = _format_latency_delta(250, 100)
+
+        assert lat_b == "100ms [green](-150ms)[/green]"
+
+    def test_zero_delta_green_with_plus_sign(self):
+        _, lat_b = _format_latency_delta(100, 100)
+
+        assert lat_b == "100ms [green](+0ms)[/green]"
+
+    def test_missing_values_render_dash(self):
+        assert _format_latency_delta(None, None) == ("-", "-")
+        lat_a, lat_b = _format_latency_delta(None, 50)
+        assert (lat_a, lat_b) == ("-", "50ms")
+
+
+class TestDetectErrorChanges:
+    def test_error_resolved(self):
+        assert _detect_error_changes("boom", None) == "[green]error resolved[/green]"
+
+    def test_new_error_truncated_to_30_chars(self):
+        result = _detect_error_changes(None, "x" * 50)
+
+        assert result == f"[red]new error: {'x' * 30}[/red]"
+
+    def test_no_change_returns_none(self):
+        assert _detect_error_changes(None, None) is None
+        assert _detect_error_changes("same", "same") is None
+
+
+class TestBuildDiffRow:
+    def test_unchanged_step_has_no_changes_or_style(self):
+        changes, sa, sb, _, _, style = _build_diff_row(_step())
+
+        assert changes == []
+        assert (sa, sb) == ("completed", "completed")
+        assert style == ""
+
+    def test_agent_change_listed(self):
+        changes, *_ = _build_diff_row(
+            _step(agent_changed=True, agent_a="llm://gpt-4o", agent_b="llm://gpt-4o-mini")
+        )
+
+        assert "agent: llm://gpt-4o -> llm://gpt-4o-mini" in changes
+
+    def test_status_change_sets_yellow_row_style(self):
+        *_, style = _build_diff_row(_step(status_changed=True))
+
+        assert style == "yellow"
+
+    def test_artifacts_and_error_changes_accumulate(self):
+        changes, *_ = _build_diff_row(
+            _step(artifacts_changed=True, error_a="boom", error_b=None)
+        )
+
+        assert "[yellow]artifacts changed[/yellow]" in changes
+        assert "[green]error resolved[/green]" in changes
+
+    def test_missing_statuses_render_dash(self):
+        _, sa, sb, *_ = _build_diff_row(_step(status_a=None, status_b=None))
+
+        assert (sa, sb) == ("-", "-")

--- a/tests/unit/trace/test_trace_parser.py
+++ b/tests/unit/trace/test_trace_parser.py
@@ -1,0 +1,66 @@
+"""Tests for trace/parser.py — the stderr trace-event filter."""
+
+from __future__ import annotations
+
+import json
+
+from binex.trace.parser import parse_trace_events
+
+
+def _event(**kwargs) -> str:
+    payload = {"_binex_trace": True, "type": "task_start"}
+    payload.update(kwargs)
+    return json.dumps(payload)
+
+
+def test_extracts_valid_events_in_order():
+    lines = [_event(type="task_start", task="a"), _event(type="log", task="b")]
+
+    events = parse_trace_events(lines)
+
+    assert [e["type"] for e in events] == ["task_start", "log"]
+
+
+def test_skips_lines_without_marker():
+    lines = ["plain stderr noise", json.dumps({"type": "task_start"}), ""]
+
+    assert parse_trace_events(lines) == []
+
+
+def test_skips_malformed_json_with_marker():
+    lines = ['{"_binex_trace": true, "type": broken', _event()]
+
+    events = parse_trace_events(lines)
+
+    assert len(events) == 1
+
+
+def test_skips_marker_with_falsy_flag():
+    lines = [json.dumps({"_binex_trace": False, "type": "log"}), _event()]
+
+    assert len(parse_trace_events(lines)) == 1
+
+
+def test_skips_non_dict_json():
+    lines = ['["_binex_trace", true]', _event()]
+
+    assert len(parse_trace_events(lines)) == 1
+
+
+def test_skips_event_without_type():
+    lines = [json.dumps({"_binex_trace": True}), _event()]
+
+    events = parse_trace_events(lines)
+
+    assert len(events) == 1
+    assert events[0]["type"] == "task_start"
+
+
+def test_strips_whitespace_around_lines():
+    lines = ["   " + _event(type="checkpoint") + "  "]
+
+    assert parse_trace_events(lines)[0]["type"] == "checkpoint"
+
+
+def test_empty_input_returns_empty_list():
+    assert parse_trace_events([]) == []


### PR DESCRIPTION
## What

The six not-a-boundary modules from the coverage triage (#124), each with the measured before → after:

| Module | Before | After | Notes |
|---|---|---|---|
| `cli/resume.py` | 25% | **89%** | store guards against real in-memory stores; presentation/exit codes via mocked `_run_resume`; `--from`/`--force` forwarding |
| `trace/parser.py` | 25% | **100%** | the stderr trace-event filter — marker, malformed JSON, falsy flag, non-dict, missing type |
| `eval/judge.py` | 60% | **100%** | mocked `litellm.acompletion`; fail-closed contract: API error, empty reply, unparseable verdict; per-assertion model resolution; 8000-char truncation |
| `cli/trace.py` | 63% | **86%** | `render_subtask_tree` grouping semantics (end matched by name, orphan children, connectors) + `trace subtasks` command; rich panels stay a boundary |
| `trace/diff_rich.py` | 0% | **45%** | pure helpers (latency delta coloring, error-change detection, row building); `_render_*` stays a boundary — the boundary runs through the terminal, not the file |
| `scheduler/engine.py` | 55% | **71%** | `_run_workflow`: status mapping (non-completed → failed), cost recording, crash records 'failed' without taking the scheduler down; `start()` loop stays a boundary |

## Verification

```
3163 passed, 1 skipped in 54.37s
All checks passed! (ruff)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)