### PR TITLE
test(e2e): complete Page Object Model — six new page objects

### DIFF
--- a/tests/e2e_playwright/conftest.py
+++ b/tests/e2e_playwright/conftest.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 from playwright.sync_api import expect
+from tests.e2e_playwright.pages.bisect_page import BisectPage
+from tests.e2e_playwright.pages.cost_dashboard_page import CostDashboardPage
+from tests.e2e_playwright.pages.dashboard_page import DashboardPage
+from tests.e2e_playwright.pages.diff_page import DiffPage
+from tests.e2e_playwright.pages.editor_page import EditorPage
 from tests.e2e_playwright.pages.export_page import ExportPage
+from tests.e2e_playwright.pages.scaffold_page import ScaffoldPage
 from tests.e2e_playwright.pages.sidebar import Sidebar
 
 # The 5s default is tuned for fast local runs; on shared CI vCPUs with
@@ -25,6 +31,30 @@ def sidebar(page) -> Sidebar:
 @pytest.fixture
 def export_page(page) -> ExportPage:
     return ExportPage(page)
+
+@pytest.fixture
+def scaffold_page(page) -> ScaffoldPage:
+    return ScaffoldPage(page)
+
+@pytest.fixture
+def editor_page(page) -> EditorPage:
+    return EditorPage(page)
+
+@pytest.fixture
+def diff_page(page) -> DiffPage:
+    return DiffPage(page)
+
+@pytest.fixture
+def bisect_page(page) -> BisectPage:
+    return BisectPage(page)
+
+@pytest.fixture
+def cost_dashboard_page(page) -> CostDashboardPage:
+    return CostDashboardPage(page)
+
+@pytest.fixture
+def dashboard_page(page) -> DashboardPage:
+    return DashboardPage(page)
 
 TOUR_DISMISSED_STATE = {
     "cookies": [],

--- a/tests/e2e_playwright/pages/bisect_page.py
+++ b/tests/e2e_playwright/pages/bisect_page.py
@@ -1,0 +1,22 @@
+from playwright.sync_api import Page
+
+
+class BisectPage:
+    """
+    Represents the bisect (first-divergence search) page of the application.
+    """
+
+    def __init__(self, page: Page):
+        """
+        Args:
+            page (Page): The Playwright Page instance.
+        """
+        self.page = page
+        self.heading_locator = page.get_by_role("heading", name="Bisect")
+        self.good_run_select_locator = page.get_by_test_id("bisect-good-run-select")
+        self.bad_run_select_locator = page.get_by_test_id("bisect-bad-run-select")
+        self.find_button_locator = page.get_by_test_id("bisect-find-btn")
+        self.threshold_slider_locator = page.get_by_test_id("bisect-threshold-slider")
+
+    def goto(self) -> None:
+        self.page.goto("/bisect")

--- a/tests/e2e_playwright/pages/cost_dashboard_page.py
+++ b/tests/e2e_playwright/pages/cost_dashboard_page.py
@@ -1,0 +1,41 @@
+from enum import Enum
+
+from playwright.sync_api import Locator, Page
+
+KPI_CARDS = ("Total Cost", "Avg per Run", "Total Runs", "Budget Used")
+CHART_SECTIONS = ("Cost Trend", "Cost by Model", "Cost by Node")
+
+
+class CostPeriod(Enum):
+    H24 = "24h"
+    D7 = "7d"
+    D30 = "30d"
+    ALL = "all"
+
+
+class CostDashboardPage:
+    """
+    Represents the cost dashboard page (/costs) of the application.
+    """
+
+    def __init__(self, page: Page):
+        """
+        Args:
+            page (Page): The Playwright Page instance.
+        """
+        self.page = page
+        self.period_select_locator = page.get_by_label("Select period")
+
+    def goto(self) -> None:
+        self.page.goto("/costs")
+
+    def kpi_card(self, name: str) -> Locator:
+        return self.page.get_by_text(name)
+
+    def chart_section(self, name: str) -> Locator:
+        return self.page.get_by_text(name)
+
+    def select_period(self, period: CostPeriod) -> None:
+        self.period_select_locator.click()
+        # Radix Select renders its listbox in a portal at <body>, so search from page
+        self.page.get_by_role("option", name=period.value, exact=True).click()

--- a/tests/e2e_playwright/pages/dashboard_page.py
+++ b/tests/e2e_playwright/pages/dashboard_page.py
@@ -1,0 +1,24 @@
+from playwright.sync_api import Locator, Page
+
+
+class DashboardPage:
+    """
+    Represents the runs dashboard (home) page of the application.
+    """
+
+    def __init__(self, page: Page):
+        """
+        Args:
+            page (Page): The Playwright Page instance.
+        """
+        self.page = page
+        self.run_links_locator = page.locator('[data-testid^="dashboard-run-link-run_"]')
+
+    def goto(self) -> None:
+        self.page.goto("/")
+
+    def first_run_link(self) -> Locator:
+        return self.run_links_locator.first
+
+    def run_link(self, run_id: str) -> Locator:
+        return self.page.get_by_test_id(f"dashboard-run-link-{run_id}")

--- a/tests/e2e_playwright/pages/diff_page.py
+++ b/tests/e2e_playwright/pages/diff_page.py
@@ -1,0 +1,21 @@
+from playwright.sync_api import Page
+
+
+class DiffPage:
+    """
+    Represents the run comparison (Compare Runs) page of the application.
+    """
+
+    def __init__(self, page: Page):
+        """
+        Args:
+            page (Page): The Playwright Page instance.
+        """
+        self.page = page
+        self.heading_locator = page.get_by_role("heading", name="Compare Runs")
+        self.run_a_select_locator = page.get_by_test_id("diff-run-a-select")
+        self.run_b_select_locator = page.get_by_test_id("diff-run-b-select")
+        self.compare_button_locator = page.get_by_test_id("diff-compare-btn")
+
+    def goto(self) -> None:
+        self.page.goto("/diff")

--- a/tests/e2e_playwright/pages/editor_page.py
+++ b/tests/e2e_playwright/pages/editor_page.py
@@ -1,0 +1,63 @@
+from enum import Enum
+
+from playwright.sync_api import Locator, Page
+
+
+class EditorMode(Enum):
+    VISUAL = "visual"
+    YAML = "yaml"
+
+
+class PaletteNode(Enum):
+    LLM = "llm"
+    LOCAL = "local"
+    HUMAN_APPROVE = "human-approve"
+    HUMAN_INPUT = "human-input"
+    A2A = "a2a"
+
+
+class SaveAsModal:
+    """
+    Represents the Save As modal opened from the editor toolbar.
+    """
+
+    def __init__(self, page: Page):
+        self.page = page
+        self.modal_locator = page.get_by_test_id("save-as-modal")
+        self.filename_input_locator = page.get_by_test_id("save-as-filename-input")
+        self.cancel_button_locator = page.get_by_test_id("save-as-cancel-btn")
+
+    def cancel(self) -> None:
+        self.cancel_button_locator.click()
+
+
+class EditorPage:
+    """
+    Represents the visual/YAML workflow editor page of the application.
+    """
+
+    def __init__(self, page: Page):
+        """
+        Args:
+            page (Page): The Playwright Page instance.
+        """
+        self.page = page
+        self.monaco_locator = page.locator(".monaco-editor")
+        self.yaml_mode_editor_locator = page.locator("[data-mode-id='yaml']")
+        self.save_button_locator = page.get_by_test_id("editor-save-btn")
+
+    def goto(self) -> None:
+        self.page.goto("/editor")
+
+    def mode_button(self, mode: EditorMode) -> Locator:
+        return self.page.get_by_test_id(f"editor-mode-{mode.value}")
+
+    def switch_mode(self, mode: EditorMode) -> None:
+        self.mode_button(mode).click()
+
+    def palette_node(self, node: PaletteNode) -> Locator:
+        return self.page.get_by_test_id(f"palette-node-{node.value}")
+
+    def open_save_as(self) -> SaveAsModal:
+        self.save_button_locator.click()
+        return SaveAsModal(self.page)

--- a/tests/e2e_playwright/pages/scaffold_page.py
+++ b/tests/e2e_playwright/pages/scaffold_page.py
@@ -1,0 +1,50 @@
+from enum import Enum
+
+from playwright.sync_api import Locator, Page
+
+
+class ScaffoldTab(Enum):
+    TEMPLATE = "template"
+    BLANK = "blank"
+
+
+class ScaffoldPage:
+    """
+    Represents the scaffold (Create Workflow) page of the application.
+    """
+
+    def __init__(self, page: Page):
+        """
+        Args:
+            page (Page): The Playwright Page instance.
+        """
+        self.page = page
+        self.heading_locator = page.get_by_role("heading", name="Create Workflow")
+        self.dsl_input_locator = page.get_by_test_id("scaffold-dsl-input")
+        self.generate_button_locator = page.get_by_test_id("scaffold-generate-btn")
+        self.yaml_output_locator = page.get_by_test_id("scaffold-yaml-output")
+        self.pattern_cards_locator = page.locator('[data-testid^="scaffold-pattern-"]')
+        self.open_editor_button_locator = page.get_by_test_id("scaffold-open-editor-btn")
+        self.blank_open_editor_button_locator = page.get_by_test_id(
+            "scaffold-blank-open-editor-btn"
+        )
+
+    def goto(self) -> None:
+        self.page.goto("/scaffold")
+
+    def tab(self, tab: ScaffoldTab) -> Locator:
+        return self.page.get_by_test_id(f"scaffold-tab-{tab.value}")
+
+    def open_tab(self, tab: ScaffoldTab) -> None:
+        self.tab(tab).click()
+
+    def generate_from_dsl(self, dsl: str) -> None:
+        """Fill the DSL input and click Generate."""
+        self.dsl_input_locator.fill(dsl)
+        self.generate_button_locator.click()
+
+    def yaml_text(self) -> str:
+        return self.yaml_output_locator.inner_text()
+
+    def open_in_editor(self) -> None:
+        self.open_editor_button_locator.click()

--- a/tests/e2e_playwright/test_cost_dashboard.py
+++ b/tests/e2e_playwright/test_cost_dashboard.py
@@ -1,23 +1,26 @@
 """E2E: Cost Dashboard — KPI cards, charts, period selector (standalone page at /costs)."""
 import pytest
 from playwright.sync_api import Page, expect
+from tests.e2e_playwright.pages.cost_dashboard_page import (
+    CHART_SECTIONS,
+    KPI_CARDS,
+    CostDashboardPage,
+    CostPeriod,
+)
 
 pytestmark = pytest.mark.e2e
 
 
-@pytest.mark.parametrize("period", ["24h", "7d", "30d", "all"])
-def test_cost_dashboard(page: Page, period: str) -> None:
+@pytest.mark.parametrize("period", list(CostPeriod))
+def test_cost_dashboard(
+    page: Page, cost_dashboard_page: CostDashboardPage, period: CostPeriod
+) -> None:
     """Test Cost Dashboard page for KPI cards, charts, and period selector."""
-    page.goto("/costs")
-    kpi_cards = ["Total Cost", "Avg per Run", "Total Runs", "Budget Used"]
-    for card in kpi_cards:
-        expect(page.get_by_text(card)).to_be_visible()
-    period_select = page.get_by_label("Select period")
-    expect(period_select).to_be_visible()
-    period_select.click()
-    # Radix Select renders its listbox in a portal at <body>, so search from page
-    page.get_by_role("option", name=period, exact=True).click()
-    expect(period_select).to_have_text(period)
-    expect(page.get_by_text("Cost Trend")).to_be_visible()
-    expect(page.get_by_text("Cost by Model")).to_be_visible()
-    expect(page.get_by_text("Cost by Node")).to_be_visible()
+    cost_dashboard_page.goto()
+    for card in KPI_CARDS:
+        expect(cost_dashboard_page.kpi_card(card)).to_be_visible()
+    expect(cost_dashboard_page.period_select_locator).to_be_visible()
+    cost_dashboard_page.select_period(period)
+    expect(cost_dashboard_page.period_select_locator).to_have_text(period.value)
+    for section in CHART_SECTIONS:
+        expect(cost_dashboard_page.chart_section(section)).to_be_visible()

--- a/tests/e2e_playwright/test_diff_bisect.py
+++ b/tests/e2e_playwright/test_diff_bisect.py
@@ -1,36 +1,25 @@
 """E2E: Diff and Bisect pages — UI elements and interaction."""
 import pytest
 from playwright.sync_api import Page, expect
+from tests.e2e_playwright.pages.bisect_page import BisectPage
+from tests.e2e_playwright.pages.diff_page import DiffPage
 
 pytestmark = pytest.mark.e2e
 
 
-@pytest.mark.parametrize(
-    "path, heading, select_a, select_b, compare_button, slider", [
-            (
-                "/diff", "Compare Runs", "diff-run-a-select", "diff-run-b-select",
-                "diff-compare-btn", None
-            ),
-            (
-                "/bisect", "Bisect", "bisect-good-run-select", "bisect-bad-run-select",
-                "bisect-find-btn", "bisect-threshold-slider")
-        ]
-    )
-def test_diff_bisect_pages(
-    page: Page,
-    path: str,
-    heading: str,
-    select_a: str,
-    select_b: str,
-    compare_button: str,
-    slider: str | None
-    ) -> None:
-    page.goto(path)
-    expect(page.get_by_role("heading", name=heading).first).to_be_visible()
-    expect(page.get_by_test_id(select_a)).to_be_visible()
-    expect(page.get_by_test_id(select_b)).to_be_visible()
-    expect(page.get_by_test_id(compare_button)).to_be_disabled()
-    if slider:
-        expect(page.get_by_test_id(slider)).to_be_visible()
-        expect(page.get_by_test_id(slider)).to_have_value("0.9")
+def test_diff_page(page: Page, diff_page: DiffPage) -> None:
+    diff_page.goto()
+    expect(diff_page.heading_locator.first).to_be_visible()
+    expect(diff_page.run_a_select_locator).to_be_visible()
+    expect(diff_page.run_b_select_locator).to_be_visible()
+    expect(diff_page.compare_button_locator).to_be_disabled()
 
+
+def test_bisect_page(page: Page, bisect_page: BisectPage) -> None:
+    bisect_page.goto()
+    expect(bisect_page.heading_locator.first).to_be_visible()
+    expect(bisect_page.good_run_select_locator).to_be_visible()
+    expect(bisect_page.bad_run_select_locator).to_be_visible()
+    expect(bisect_page.find_button_locator).to_be_disabled()
+    expect(bisect_page.threshold_slider_locator).to_be_visible()
+    expect(bisect_page.threshold_slider_locator).to_have_value("0.9")

--- a/tests/e2e_playwright/test_run_analysis.py
+++ b/tests/e2e_playwright/test_run_analysis.py
@@ -2,6 +2,7 @@
 
 import pytest
 from playwright.sync_api import Page, Route, expect
+from tests.e2e_playwright.pages.dashboard_page import DashboardPage
 
 pytestmark = pytest.mark.e2e
 
@@ -138,12 +139,12 @@ def _mock_run_api(page) -> None:
         route.fulfill(json=FAKE_LINEAGE)
     page.route("**/api/v1/runs/run_fake_0001/lineage", handle_lineage)
 
-def test_run_analysis_pages(page: Page) -> None:
+def test_run_analysis_pages(page: Page, dashboard_page: DashboardPage) -> None:
     """Test run analysis pages (Debug, Trace, Diagnose) for a real run."""
     _mock_run_api(page)
-    page.goto("/")
+    dashboard_page.goto()
     # Find first run link in the table
-    first_run = page.locator('[data-testid^="dashboard-run-link-run_"]').first
+    first_run = dashboard_page.first_run_link()
     expect(first_run).to_be_visible()
     expect(first_run).to_have_attribute("href", "/runs/run_fake_0001")
 

--- a/tests/e2e_playwright/test_scaffold_flow.py
+++ b/tests/e2e_playwright/test_scaffold_flow.py
@@ -3,23 +3,19 @@
 import pytest
 import yaml
 from playwright.sync_api import Page, expect
+from tests.e2e_playwright.pages.scaffold_page import ScaffoldPage, ScaffoldTab
 
 pytestmark = pytest.mark.e2e
 
 
-def test_scaffold_flow_dsl(page: Page) -> None:
-    page.goto("/scaffold")
-    expect(page.get_by_role("heading", name="Create Workflow").first).to_be_visible()
-    dsl_input = page.get_by_test_id("scaffold-dsl-input")
-    dsl_input.fill("A -> B -> C")
-    generate_btn = page.get_by_test_id("scaffold-generate-btn")
-    generate_btn.click()
-    yaml_output = page.get_by_test_id("scaffold-yaml-output")
-    expect(yaml_output).to_be_visible()
-    expect(yaml_output).to_contain_text("nodes:")
-    yaml_content = yaml_output.inner_text()
+def test_scaffold_flow_dsl(page: Page, scaffold_page: ScaffoldPage) -> None:
+    scaffold_page.goto()
+    expect(scaffold_page.heading_locator.first).to_be_visible()
+    scaffold_page.generate_from_dsl("A -> B -> C")
+    expect(scaffold_page.yaml_output_locator).to_be_visible()
+    expect(scaffold_page.yaml_output_locator).to_contain_text("nodes:")
     try:
-        parsed_data = yaml.safe_load(yaml_content)
+        parsed_data = yaml.safe_load(scaffold_page.yaml_text())
         assert isinstance(parsed_data, (dict, list))
         nodes = parsed_data.get("nodes", {})
         assert isinstance(nodes, dict)
@@ -28,18 +24,14 @@ def test_scaffold_flow_dsl(page: Page) -> None:
     except yaml.YAMLError as e:
         pytest.fail(f"Failed to parse YAML: {e}")
 
-def test_scaffold_flow_template(page: Page) -> None:
-    page.goto("/scaffold")
-    expect(page.get_by_role("heading", name="Create Workflow").first).to_be_visible()
-    template_tab = page.get_by_test_id("scaffold-tab-template")
-    template_tab.click()
-    pattern_cards = page.locator('[data-testid^="scaffold-pattern-"]')
-    expect(pattern_cards).to_have_count(25)
+def test_scaffold_flow_template(page: Page, scaffold_page: ScaffoldPage) -> None:
+    scaffold_page.goto()
+    expect(scaffold_page.heading_locator.first).to_be_visible()
+    scaffold_page.open_tab(ScaffoldTab.TEMPLATE)
+    expect(scaffold_page.pattern_cards_locator).to_have_count(25)
 
-def test_scaffold_flow_blank(page: Page) -> None:
-    page.goto("/scaffold")
-    expect(page.get_by_role("heading", name="Create Workflow").first).to_be_visible()
-    blank_tab = page.get_by_test_id("scaffold-tab-blank")
-    blank_tab.click()
-    open_editor_btn = page.get_by_test_id("scaffold-blank-open-editor-btn")
-    expect(open_editor_btn).to_be_visible()
+def test_scaffold_flow_blank(page: Page, scaffold_page: ScaffoldPage) -> None:
+    scaffold_page.goto()
+    expect(scaffold_page.heading_locator.first).to_be_visible()
+    scaffold_page.open_tab(ScaffoldTab.BLANK)
+    expect(scaffold_page.blank_open_editor_button_locator).to_be_visible()

--- a/tests/e2e_playwright/test_visual_editor.py
+++ b/tests/e2e_playwright/test_visual_editor.py
@@ -2,71 +2,56 @@
 
 import pytest
 from playwright.sync_api import Page, expect
+from tests.e2e_playwright.pages.editor_page import EditorMode, EditorPage, PaletteNode
+from tests.e2e_playwright.pages.scaffold_page import ScaffoldPage
 
 pytestmark = pytest.mark.e2e
 
 
-def test_editor_mode_toggle_visual(page: Page) -> None:
+def test_editor_mode_toggle_visual(page: Page, editor_page: EditorPage) -> None:
     """Test the Visual Editor mode toggle."""
-    page.goto("/editor")
-    visual_btn = page.get_by_test_id("editor-mode-visual")
-    yaml_btn = page.get_by_test_id("editor-mode-yaml")
-    expect(visual_btn).to_be_visible()
-    expect(yaml_btn).to_be_visible()
-    visual_btn.click()
-    expect(page.get_by_test_id("palette-node-llm")).to_be_visible()
-    expect(page.get_by_test_id("palette-node-local")).to_be_visible()
-    expect(page.get_by_test_id("palette-node-human-approve")).to_be_visible()
-    expect(page.get_by_test_id("palette-node-human-input")).to_be_visible()
-    expect(page.get_by_test_id("palette-node-a2a")).to_be_visible()
-    yaml_btn.click()
-    expect(page.locator(".monaco-editor")).to_be_visible()
+    editor_page.goto()
+    expect(editor_page.mode_button(EditorMode.VISUAL)).to_be_visible()
+    expect(editor_page.mode_button(EditorMode.YAML)).to_be_visible()
+    editor_page.switch_mode(EditorMode.VISUAL)
+    for node in PaletteNode:
+        expect(editor_page.palette_node(node)).to_be_visible()
+    editor_page.switch_mode(EditorMode.YAML)
+    expect(editor_page.monaco_locator).to_be_visible()
 
-def test_editor_mode_toggle_yaml(page: Page) -> None:
+def test_editor_mode_toggle_yaml(page: Page, editor_page: EditorPage) -> None:
     """Test the YAML Editor mode toggle."""
-    page.goto("/editor")
-    visual_btn = page.get_by_test_id("editor-mode-visual")
-    yaml_btn = page.get_by_test_id("editor-mode-yaml")
-    expect(visual_btn).to_be_visible()
-    expect(yaml_btn).to_be_visible()
-    expect(page.locator(".monaco-editor")).to_be_visible()
-    editor_yaml = page.locator("[data-mode-id='yaml']")
-    expect(editor_yaml).to_be_visible()
+    editor_page.goto()
+    expect(editor_page.mode_button(EditorMode.VISUAL)).to_be_visible()
+    expect(editor_page.mode_button(EditorMode.YAML)).to_be_visible()
+    expect(editor_page.monaco_locator).to_be_visible()
+    expect(editor_page.yaml_mode_editor_locator).to_be_visible()
 
-def test_scaffold_to_editor_flow(page: Page) -> None:
+def test_scaffold_to_editor_flow(
+    page: Page, scaffold_page: ScaffoldPage, editor_page: EditorPage
+) -> None:
     """Test the Scaffold → Editor flow."""
-    page.goto("/scaffold")
-    dsl_input = page.get_by_test_id("scaffold-dsl-input")
-    expect(dsl_input).to_be_visible()
-    dsl_input.fill("A -> B -> C")
-    generate_btn = page.get_by_test_id("scaffold-generate-btn")
-    expect(generate_btn).to_be_visible()
-    generate_btn.click()
-    open_editor_btn = page.get_by_test_id("scaffold-open-editor-btn")
-    expect(open_editor_btn).to_be_visible()
-    open_editor_btn.click()
+    scaffold_page.goto()
+    expect(scaffold_page.dsl_input_locator).to_be_visible()
+    scaffold_page.generate_from_dsl("A -> B -> C")
+    expect(scaffold_page.open_editor_button_locator).to_be_visible()
+    scaffold_page.open_in_editor()
     expect(page).to_have_url("/editor")
-    expect(page.locator(".monaco-editor")).to_contain_text("nodes:")
+    expect(editor_page.monaco_locator).to_contain_text("nodes:")
 
 
-def test_editor_save_as_modal(page: Page) -> None:
+def test_editor_save_as_modal(
+    page: Page, scaffold_page: ScaffoldPage, editor_page: EditorPage
+) -> None:
     """Test the Save As modal in the Visual Editor."""
-    page.goto("/scaffold")
-    dsl_input = page.get_by_test_id("scaffold-dsl-input")
-    dsl_input.fill("A -> B -> C")
-    generate_btn = page.get_by_test_id("scaffold-generate-btn")
-    generate_btn.click()
-    open_editor_btn = page.get_by_test_id("scaffold-open-editor-btn")
-    open_editor_btn.click()
+    scaffold_page.goto()
+    scaffold_page.generate_from_dsl("A -> B -> C")
+    scaffold_page.open_in_editor()
     expect(page).to_have_url("/editor")
-    save_btn = page.get_by_test_id("editor-save-btn")
-    expect(save_btn).to_be_visible()
-    save_btn.click()
-    save_modal = page.get_by_test_id("save-as-modal")
-    expect(save_modal).to_be_visible()
-    filename_input = page.get_by_test_id("save-as-filename-input")
-    expect(filename_input).to_be_visible()
-    cancel_btn = page.get_by_test_id("save-as-cancel-btn")
-    expect(cancel_btn).to_be_visible()
-    cancel_btn.click()
-    expect(save_modal).not_to_be_visible()
+    expect(editor_page.save_button_locator).to_be_visible()
+    save_modal = editor_page.open_save_as()
+    expect(save_modal.modal_locator).to_be_visible()
+    expect(save_modal.filename_input_locator).to_be_visible()
+    expect(save_modal.cancel_button_locator).to_be_visible()
+    save_modal.cancel()
+    expect(save_modal.modal_locator).not_to_be_visible()

--- a/tests/unit/cli/test_resume_cmd.py
+++ b/tests/unit/cli/test_resume_cmd.py
@@ -1,0 +1,133 @@
+"""Tests for the `binex resume` CLI command (cli/resume.py).
+
+The ResumeEngine itself is covered in tests/unit/runtime/test_resume.py;
+here we pin the CLI layer: store guards, output formats, exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+
+from binex.cli.resume import resume_cmd
+from binex.models.execution import RunSummary
+from binex.runtime.resume import ResumeResult
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+
+def _summary(**kwargs) -> RunSummary:
+    defaults = dict(
+        run_id="run-child",
+        workflow_name="wf",
+        status="completed",
+        total_nodes=3,
+        completed_nodes=3,
+        resumed_from="run-parent",
+    )
+    defaults.update(kwargs)
+    return RunSummary(**defaults)
+
+
+def _result(**kwargs) -> ResumeResult:
+    defaults = dict(summary=_summary(), resumed_nodes=1, cached_nodes=2, warnings=[])
+    defaults.update(kwargs)
+    return ResumeResult(**defaults)
+
+
+def _patch_run_resume(result=None, error=None):
+    mock = AsyncMock(return_value=result)
+    if error is not None:
+        mock.side_effect = error
+    return patch("binex.cli.resume._run_resume", mock)
+
+
+# ---------------------------------------------------------------------------
+# Store guards (real _run_resume against in-memory stores)
+# ---------------------------------------------------------------------------
+
+
+def test_resume_unknown_run_exits_1_with_error():
+    stores = (InMemoryExecutionStore(), InMemoryArtifactStore())
+
+    with patch("binex.cli.resume.get_stores", return_value=stores):
+        result = CliRunner().invoke(resume_cmd, ["run-ghost"])
+
+    assert result.exit_code == 1
+    assert "Run 'run-ghost' not found" in result.output
+
+
+def test_resume_run_without_workflow_path_exits_1():
+    exec_store = InMemoryExecutionStore()
+    stores = (exec_store, InMemoryArtifactStore())
+    import asyncio
+
+    asyncio.run(exec_store.create_run(
+        _summary(run_id="run-nopath", workflow_path=None, status="failed")
+    ))
+
+    with patch("binex.cli.resume.get_stores", return_value=stores):
+        result = CliRunner().invoke(resume_cmd, ["run-nopath"])
+
+    assert result.exit_code == 1
+    assert "no recorded workflow_path" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Presentation layer (mocked _run_resume)
+# ---------------------------------------------------------------------------
+
+
+def test_resume_text_output_and_exit_0_on_completed():
+    with _patch_run_resume(_result()):
+        result = CliRunner().invoke(resume_cmd, ["run-parent"])
+
+    assert result.exit_code == 0
+    assert "Resume Run ID: run-child" in result.output
+    assert "Resumed from: run-parent" in result.output
+    assert "Nodes: 3/3 completed (2 cached, 1 re-run)" in result.output
+
+
+def test_resume_failed_status_exits_1():
+    with _patch_run_resume(
+        _result(summary=_summary(status="failed", completed_nodes=2, failed_nodes=1))
+    ):
+        result = CliRunner().invoke(resume_cmd, ["run-parent"])
+
+    assert result.exit_code == 1
+    assert "Failed: 1" in result.output
+
+
+def test_resume_json_output_includes_node_counts():
+    with _patch_run_resume(_result()):
+        result = CliRunner().invoke(resume_cmd, ["run-parent", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["run_id"] == "run-child"
+    assert data["resumed_nodes"] == 1
+    assert data["cached_nodes"] == 2
+
+
+def test_resume_prints_warnings_with_marker():
+    with _patch_run_resume(_result(warnings=["topology drift detected"])):
+        result = CliRunner().invoke(resume_cmd, ["run-parent"])
+
+    assert "⚠ topology drift detected" in result.output
+
+
+def test_resume_cost_line_only_when_positive():
+    with _patch_run_resume(_result(summary=_summary(total_cost=0.1234))):
+        result = CliRunner().invoke(resume_cmd, ["run-parent"])
+
+    assert "Cost (cumulative): $0.1234" in result.output
+
+
+def test_resume_forwards_from_and_force_flags():
+    mock = AsyncMock(return_value=_result())
+
+    with patch("binex.cli.resume._run_resume", mock):
+        CliRunner().invoke(resume_cmd, ["run-parent", "--from", "step3", "--force"])
+
+    mock.assert_awaited_once_with("run-parent", "step3", True)

--- a/tests/unit/cli/test_trace_subtask_tree.py
+++ b/tests/unit/cli/test_trace_subtask_tree.py
@@ -1,0 +1,122 @@
+"""Tests for render_subtask_tree() and `binex trace subtasks` (cli/trace.py).
+
+The grouping/rendering logic is pure (events in, string out) — only the
+rich panel styling elsewhere in cli/trace.py is a conscious boundary.
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from binex.cli.trace import render_subtask_tree, trace_subtasks_cmd
+
+
+def _start(name: str) -> dict:
+    return {"type": "task_start", "name": name}
+
+
+def _end(name: str, status: str = "ok", duration: float = 1.5, error: str | None = None) -> dict:
+    ev = {"type": "task_end", "name": name, "status": status, "duration_s": duration}
+    if error:
+        ev["error"] = error
+    return ev
+
+
+def test_empty_events_placeholder():
+    assert render_subtask_tree([]) == "(no trace events)"
+
+
+def test_completed_task_shows_check_and_duration():
+    tree = render_subtask_tree([_start("fetch"), _end("fetch", duration=3.1)])
+
+    assert "fetch" in tree
+    assert "✅ 3.1s" in tree
+
+
+def test_failed_task_shows_error_and_duration():
+    tree = render_subtask_tree(
+        [_start("parse"), _end("parse", status="error", duration=30.0, error="boom")]
+    )
+
+    assert "❌ boom (30.0s)" in tree
+
+
+def test_task_without_end_marked_not_reached():
+    tree = render_subtask_tree([_start("late")])
+
+    assert "⏸ not reached" in tree
+
+
+def test_children_attach_to_current_task():
+    events = [
+        _start("work"),
+        {"type": "log", "message": "step one"},
+        {"type": "checkpoint", "label": "half-way"},
+        _end("work"),
+    ]
+
+    tree = render_subtask_tree(events)
+
+    assert 'log: "step one"' in tree
+    assert 'checkpoint: "half-way"' in tree
+
+
+def test_orphan_children_before_first_task_ignored():
+    events = [{"type": "log", "message": "orphan"}, _start("a"), _end("a")]
+
+    tree = render_subtask_tree(events)
+
+    assert "orphan" not in tree
+
+
+def test_task_end_matched_by_name_only():
+    # end for a different name must not close the current task
+    events = [_start("a"), _end("b"), _start("c"), _end("c")]
+
+    tree = render_subtask_tree(events)
+
+    assert "⏸ not reached" in tree  # task "a" never ended
+    assert "✅" in tree  # task "c" did
+
+
+def test_tree_connectors_last_vs_middle():
+    events = [_start("first"), _end("first"), _start("second"), _end("second")]
+
+    lines = render_subtask_tree(events).splitlines()
+
+    assert lines[0].startswith("├─")
+    assert lines[1].startswith("└─")
+
+
+# ---------------------------------------------------------------------------
+# binex trace subtasks (file → parse → render)
+# ---------------------------------------------------------------------------
+
+
+def test_subtasks_command_renders_from_stderr_file(tmp_path):
+    stderr_file = tmp_path / "stderr.log"
+    events = [
+        {"_binex_trace": True, "type": "task_start", "name": "fetch"},
+        {"_binex_trace": True, "type": "task_end", "name": "fetch",
+         "status": "ok", "duration_s": 2.0},
+    ]
+    stderr_file.write_text(
+        "random noise\n" + "\n".join(json.dumps(e) for e in events) + "\n"
+    )
+
+    result = CliRunner().invoke(trace_subtasks_cmd, [str(stderr_file)])
+
+    assert result.exit_code == 0
+    assert "✅ 2.0s" in result.output
+
+
+def test_subtasks_command_no_events_exits_1(tmp_path):
+    stderr_file = tmp_path / "stderr.log"
+    stderr_file.write_text("no trace here\n")
+
+    result = CliRunner().invoke(trace_subtasks_cmd, [str(stderr_file)])
+
+    assert result.exit_code == 1
+    assert "No binex-trace events found" in result.output

--- a/tests/unit/eval/test_judge_llm_call.py
+++ b/tests/unit/eval/test_judge_llm_call.py
@@ -1,0 +1,100 @@
+"""Tests for the make_judge() LLM-call closure in eval/judge.py.
+
+parse_verdict/resolve_judge_model are covered elsewhere; here we pin the
+async judge itself with a mocked litellm.acompletion — including the
+fail-closed contract: a broken judge must never green-light a regression.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from binex.eval.judge import make_judge
+from binex.models.assertion import Assertion
+
+
+def _llm_reply(text: str) -> dict:
+    return {"choices": [{"message": {"content": text}}]}
+
+
+def _assertion(**kwargs) -> Assertion:
+    defaults = dict(judge="output must mention cats")
+    defaults.update(kwargs)
+    return Assertion(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_pass_reply_parsed():
+    judge = make_judge()
+    mock = AsyncMock(return_value=_llm_reply("PASS: mentions cats"))
+
+    with patch("litellm.acompletion", mock):
+        passed, reason = await judge(_assertion(), "cats are great")
+
+    assert passed is True
+    assert reason == "mentions cats"
+
+
+@pytest.mark.asyncio
+async def test_fail_reply_parsed():
+    judge = make_judge()
+    mock = AsyncMock(return_value=_llm_reply("FAIL: no cats found"))
+
+    with patch("litellm.acompletion", mock):
+        passed, reason = await judge(_assertion(), "dogs only")
+
+    assert passed is False
+    assert reason == "no cats found"
+
+
+@pytest.mark.asyncio
+async def test_llm_exception_fails_closed():
+    judge = make_judge()
+    mock = AsyncMock(side_effect=ConnectionError("api down"))
+
+    with patch("litellm.acompletion", mock):
+        passed, reason = await judge(_assertion(), "anything")
+
+    assert passed is False
+    assert "judge error" in reason
+    assert "api down" in reason
+
+
+@pytest.mark.asyncio
+async def test_empty_reply_fails_closed():
+    judge = make_judge()
+    mock = AsyncMock(return_value=_llm_reply(None))
+
+    with patch("litellm.acompletion", mock):
+        passed, reason = await judge(_assertion(), "anything")
+
+    assert passed is False
+    assert "unparseable" in reason
+
+
+@pytest.mark.asyncio
+async def test_model_resolution_assertion_wins_over_default():
+    judge = make_judge(default_model="default-model")
+    mock = AsyncMock(return_value=_llm_reply("PASS: ok"))
+
+    with patch("litellm.acompletion", mock):
+        await judge(_assertion(judge_model="per-assertion-model"), "text")
+
+    assert mock.await_args.kwargs["model"] == "per-assertion-model"
+
+
+@pytest.mark.asyncio
+async def test_output_truncated_to_max_chars():
+    judge = make_judge()
+    mock = AsyncMock(return_value=_llm_reply("PASS: ok"))
+    long_output = "x" * 10_000
+
+    with patch("litellm.acompletion", mock):
+        await judge(_assertion(judge="rubric text"), long_output)
+
+    user_msg = mock.await_args.kwargs["messages"][1]["content"]
+    assert "rubric text" in user_msg
+    assert "x" * 8000 in user_msg
+    assert "x" * 8001 not in user_msg

--- a/tests/unit/scheduler/test_engine_run_workflow.py
+++ b/tests/unit/scheduler/test_engine_run_workflow.py
@@ -1,0 +1,106 @@
+"""Tests for SchedulerEngine._run_workflow — the actual execution path.
+
+_tick/rescan/skip logic is covered in test_scheduler_engine.py; the start()
+loop (signal handlers + sleep) is a conscious boundary. Here we pin what
+happens when a due workflow actually runs: status mapping, cost recording,
+and the exception contract (a crashing workflow records 'failed' and never
+takes the scheduler down).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from binex.models.execution import RunSummary
+from binex.scheduler.engine import SchedulerEngine
+from binex.scheduler.models import ScheduledWorkflow, SchedulerState
+from binex.stores.backends.memory import InMemoryArtifactStore, InMemoryExecutionStore
+
+
+def _wf(name: str = "wf") -> ScheduledWorkflow:
+    return ScheduledWorkflow(
+        name=name,
+        path="/tmp/wf.yaml",
+        schedule="*/5 * * * *",
+        next_run=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+
+def _engine(wf: ScheduledWorkflow) -> SchedulerEngine:
+    return SchedulerEngine(workflows=[wf], state=SchedulerState())
+
+
+def _summary(status: str, total_cost: float = 0.0) -> RunSummary:
+    return RunSummary(
+        run_id="run-1",
+        workflow_name="wf",
+        status=status,
+        total_nodes=1,
+        completed_nodes=1,
+        total_cost=total_cost,
+    )
+
+
+def _patches(run_result=None, load_error=None):
+    """Patch the function-local imports of _run_workflow."""
+    orchestrator = MagicMock()
+    orchestrator.run_workflow = AsyncMock(return_value=run_result)
+    load = MagicMock(return_value=MagicMock(name="spec"))
+    if load_error is not None:
+        load.side_effect = load_error
+    return (
+        patch("binex.workflow_spec.loader.load_workflow", load),
+        patch(
+            "binex.cli.get_stores",
+            return_value=(InMemoryExecutionStore(), InMemoryArtifactStore()),
+        ),
+        patch(
+            "binex.runtime.orchestrator.Orchestrator",
+            MagicMock(return_value=orchestrator),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_completed_run_recorded_with_cost():
+    wf = _wf()
+    engine = _engine(wf)
+    p_load, p_stores, p_orch = _patches(run_result=_summary("completed", total_cost=0.5))
+
+    with p_load, p_stores, p_orch:
+        await engine._run_workflow(wf)
+
+    entry = engine.state.history[0]
+    assert entry.workflow == "wf"
+    assert entry.status == "completed"
+    assert entry.cost == 0.5
+    assert entry.run_id.startswith("sched-wf-")
+
+
+@pytest.mark.asyncio
+async def test_non_completed_status_mapped_to_failed():
+    wf = _wf()
+    engine = _engine(wf)
+    p_load, p_stores, p_orch = _patches(run_result=_summary("over_budget"))
+
+    with p_load, p_stores, p_orch:
+        await engine._run_workflow(wf)
+
+    assert engine.state.history[0].status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_workflow_exception_recorded_as_failed_not_raised():
+    wf = _wf()
+    engine = _engine(wf)
+    p_load, p_stores, p_orch = _patches(load_error=FileNotFoundError("wf.yaml gone"))
+
+    with p_load, p_stores, p_orch:
+        await engine._run_workflow(wf)  # must not raise
+
+    entry = engine.state.history[0]
+    assert entry.status == "failed"
+    assert entry.cost is None

--- a/tests/unit/trace/test_diff_rich_helpers.py
+++ b/tests/unit/trace/test_diff_rich_helpers.py
@@ -1,0 +1,101 @@
+"""Tests for the pure helpers of trace/diff_rich.py.
+
+The `_render_*` functions (rich Console output) are a conscious boundary —
+see docs/contributing/testing.md; the boundary runs through the terminal,
+not through the file, so the computational helpers are tested here.
+"""
+
+from __future__ import annotations
+
+from binex.trace.diff_rich import (
+    _build_diff_row,
+    _detect_error_changes,
+    _format_latency_delta,
+)
+
+
+def _step(**kwargs) -> dict:
+    defaults = dict(
+        agent_changed=False,
+        agent_a="local://echo",
+        agent_b="local://echo",
+        artifacts_changed=False,
+        status_changed=False,
+        latency_a=100,
+        latency_b=100,
+        status_a="completed",
+        status_b="completed",
+    )
+    defaults.update(kwargs)
+    return defaults
+
+
+class TestFormatLatencyDelta:
+    def test_regression_colored_red_with_plus(self):
+        lat_a, lat_b = _format_latency_delta(100, 250)
+
+        assert lat_a == "100ms"
+        assert lat_b == "250ms [red](+150ms)[/red]"
+
+    def test_improvement_colored_green(self):
+        _, lat_b = _format_latency_delta(250, 100)
+
+        assert lat_b == "100ms [green](-150ms)[/green]"
+
+    def test_zero_delta_green_with_plus_sign(self):
+        _, lat_b = _format_latency_delta(100, 100)
+
+        assert lat_b == "100ms [green](+0ms)[/green]"
+
+    def test_missing_values_render_dash(self):
+        assert _format_latency_delta(None, None) == ("-", "-")
+        lat_a, lat_b = _format_latency_delta(None, 50)
+        assert (lat_a, lat_b) == ("-", "50ms")
+
+
+class TestDetectErrorChanges:
+    def test_error_resolved(self):
+        assert _detect_error_changes("boom", None) == "[green]error resolved[/green]"
+
+    def test_new_error_truncated_to_30_chars(self):
+        result = _detect_error_changes(None, "x" * 50)
+
+        assert result == f"[red]new error: {'x' * 30}[/red]"
+
+    def test_no_change_returns_none(self):
+        assert _detect_error_changes(None, None) is None
+        assert _detect_error_changes("same", "same") is None
+
+
+class TestBuildDiffRow:
+    def test_unchanged_step_has_no_changes_or_style(self):
+        changes, sa, sb, _, _, style = _build_diff_row(_step())
+
+        assert changes == []
+        assert (sa, sb) == ("completed", "completed")
+        assert style == ""
+
+    def test_agent_change_listed(self):
+        changes, *_ = _build_diff_row(
+            _step(agent_changed=True, agent_a="llm://gpt-4o", agent_b="llm://gpt-4o-mini")
+        )
+
+        assert "agent: llm://gpt-4o -> llm://gpt-4o-mini" in changes
+
+    def test_status_change_sets_yellow_row_style(self):
+        *_, style = _build_diff_row(_step(status_changed=True))
+
+        assert style == "yellow"
+
+    def test_artifacts_and_error_changes_accumulate(self):
+        changes, *_ = _build_diff_row(
+            _step(artifacts_changed=True, error_a="boom", error_b=None)
+        )
+
+        assert "[yellow]artifacts changed[/yellow]" in changes
+        assert "[green]error resolved[/green]" in changes
+
+    def test_missing_statuses_render_dash(self):
+        _, sa, sb, *_ = _build_diff_row(_step(status_a=None, status_b=None))
+
+        assert (sa, sb) == ("-", "-")

--- a/tests/unit/trace/test_trace_parser.py
+++ b/tests/unit/trace/test_trace_parser.py
@@ -1,0 +1,66 @@
+"""Tests for trace/parser.py — the stderr trace-event filter."""
+
+from __future__ import annotations
+
+import json
+
+from binex.trace.parser import parse_trace_events
+
+
+def _event(**kwargs) -> str:
+    payload = {"_binex_trace": True, "type": "task_start"}
+    payload.update(kwargs)
+    return json.dumps(payload)
+
+
+def test_extracts_valid_events_in_order():
+    lines = [_event(type="task_start", task="a"), _event(type="log", task="b")]
+
+    events = parse_trace_events(lines)
+
+    assert [e["type"] for e in events] == ["task_start", "log"]
+
+
+def test_skips_lines_without_marker():
+    lines = ["plain stderr noise", json.dumps({"type": "task_start"}), ""]
+
+    assert parse_trace_events(lines) == []
+
+
+def test_skips_malformed_json_with_marker():
+    lines = ['{"_binex_trace": true, "type": broken', _event()]
+
+    events = parse_trace_events(lines)
+
+    assert len(events) == 1
+
+
+def test_skips_marker_with_falsy_flag():
+    lines = [json.dumps({"_binex_trace": False, "type": "log"}), _event()]
+
+    assert len(parse_trace_events(lines)) == 1
+
+
+def test_skips_non_dict_json():
+    lines = ['["_binex_trace", true]', _event()]
+
+    assert len(parse_trace_events(lines)) == 1
+
+
+def test_skips_event_without_type():
+    lines = [json.dumps({"_binex_trace": True}), _event()]
+
+    events = parse_trace_events(lines)
+
+    assert len(events) == 1
+    assert events[0]["type"] == "task_start"
+
+
+def test_strips_whitespace_around_lines():
+    lines = ["   " + _event(type="checkpoint") + "  "]
+
+    assert parse_trace_events(lines)[0]["type"] == "checkpoint"
+
+
+def test_empty_input_returns_empty_list():
+    assert parse_trace_events([]) == []


### PR DESCRIPTION
## What

Six new page objects in `tests/e2e_playwright/pages/`, matching the house style of the existing `ExportPage`/`Sidebar` (testid-first locators, enums for variants, `goto()`, conftest fixtures):

| Page object | Covers |
|---|---|
| `ScaffoldPage` (+`ScaffoldTab`) | DSL input/generate, yaml output, template/blank tabs, open-in-editor |
| `EditorPage` (+`EditorMode`, `PaletteNode`, `SaveAsModal`) | mode toggle, palette, monaco, save-as flow |
| `DiffPage` | run A/B selects, compare button |
| `BisectPage` | good/bad selects, find button, threshold slider |
| `CostDashboardPage` (+`CostPeriod`) | KPI cards, Radix period select, chart sections |
| `DashboardPage` | run links on the home table |

Five test files refactored off raw selectors (`test_scaffold_flow`, `test_visual_editor`, `test_diff_bisect`, `test_cost_dashboard`, `test_run_analysis`). The diff/bisect parametrized test — which passed testid strings as parameters — is split into two explicit PO-based tests.

**Deliberately left raw:** `test_system_pages` — three goto+heading checks; a page object there would be ceremony without leverage.

## Verification

Local run against a seeded server (`binex hello` + `binex ui --port 8420`), same flags as CI:

```
53 passed in 22.46s
All checks passed! (ruff)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)