### PR TITLE
ci: coverage gate, nightly sweep, tests/ lint, coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install ruff
-      - run: ruff check src/
+      - run: ruff check src/ tests/
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,35 @@
+name: Coverage
+
+# Separate workflow (not a job inside ci.yml) so it gets its own status
+# badge in the README: green = the suite covers >= the gate.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev,rich]"
+      # Gate at 80: measured 82% on 2026-08 (see docs/contributing/testing.md);
+      # 2 points of headroom absorb boundary-module churn without turning the
+      # gate into noise. Raise deliberately, never lower silently.
+      - name: Run suite with coverage gate
+        run: >
+          python -m pytest tests/unit tests/integration -q
+          --cov=binex --cov-report=term --cov-report=xml
+          --cov-fail-under=80
+      - name: Upload coverage.xml
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Reused by nightly.yml
+  workflow_call:
 
 concurrency:
   group: e2e-${{ github.ref }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,30 @@
+name: Nightly
+
+# Full nightly sweep: the complete test suite on every supported Python,
+# plus the browser E2E suite. Catches drift that per-PR runs miss
+# (dependency resolution changes, flaky-under-load tests) and keeps a
+# daily signal even on quiet days.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"  # 03:00 UTC daily
+  workflow_dispatch: {}
+
+jobs:
+  full-suite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev,rich]"
+      - run: python -m pytest tests/ -q
+
+  e2e:
+    uses: ./.github/workflows/e2e.yml

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     <a href="https://github.com/Alexli18/binex/blob/master/LICENSE"><img src="https://img.shields.io/github/license/Alexli18/binex?style=flat-square" alt="License"></a>
     <a href="https://github.com/Alexli18/binex/actions"><img src="https://img.shields.io/github/actions/workflow/status/Alexli18/binex/ci.yml?style=flat-square&label=CI" alt="CI"></a>
     <a href="https://github.com/Alexli18/binex/actions/workflows/e2e.yml"><img src="https://img.shields.io/github/actions/workflow/status/Alexli18/binex/e2e.yml?style=flat-square&label=E2E" alt="E2E"></a>
+    <a href="https://github.com/Alexli18/binex/actions/workflows/coverage.yml"><img src="https://img.shields.io/github/actions/workflow/status/Alexli18/binex/coverage.yml?style=flat-square&label=coverage%E2%89%A580%25" alt="Coverage gate"></a>
     <a href="https://alexli18.github.io/binex/"><img src="https://img.shields.io/badge/docs-online-blue?style=flat-square" alt="Docs"></a>
     <a href="https://github.com/Alexli18/binex/stargazers"><img src="https://img.shields.io/github/stars/Alexli18/binex?style=flat-square" alt="Stars"></a>
   </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "mkdocs-material",
     "pytest-playwright",
     "pytest-xdist",
+    "pytest-cov",
     "respx",
     "pre-commit"
 ]


### PR DESCRIPTION
## What

Phase-4 CI polish, four items:

1. **`coverage.yml`** — new workflow running `tests/unit tests/integration` with `--cov-fail-under=80`, uploading `coverage.xml` as an artifact. A separate workflow (not a ci.yml job) deliberately: it gets its own status badge. Gate rationale is in a comment next to the number: measured **82.37%**, 2 points of headroom so boundary-module churn doesn't turn the gate into noise; raise deliberately, never lower silently.
2. **`nightly.yml`** — 03:00 UTC daily: full `pytest tests/` on 3.11/3.12/3.13 plus the browser E2E suite reused via `workflow_call` on `e2e.yml` (one-line trigger added there). `workflow_dispatch` included for manual runs.
3. **`ci.yml` lint** — `ruff check src/` → `ruff check src/ tests/`: local runs and pre-commit already lint tests, CI was the one gate that didn't.
4. **README** — coverage-gate badge (`coverage≥80%`) next to CI/E2E.

## Verification

Workflow YAML parses (all four files); the gate command run locally:

```
Required test coverage of 80% reached. Total coverage: 82.37%
3156 passed, 2 skipped in 60.52s (0:01:00)
```

**Not included (backlog):** Codecov/percentage badge — needs an external-service account and token, deliberately out of autonomous scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)