### PR TITLE
docs: fresh-eyes pass — stale counts, nav clarity, missing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,13 +204,13 @@ binex ui
   <br><sub>Side-by-side diff with filtering: changed, failed, cost delta</sub>
 </div>
 
-### 19 Pages — Full CLI Parity
+### 20 Pages — Full CLI Parity
 
 | Category | Pages |
 |----------|-------|
 | **Workflows** | Browse, Visual Editor (with tool picker & MCP config), Scaffold Wizard |
 | **Runs** | Dashboard, RunLive (SSE), RunDetail |
-| **Analysis** | Debug (input/output artifacts), Trace (Gantt timeline), Diagnose (root-cause), Lineage (artifact graph) |
+| **Analysis** | Debug (input/output artifacts), Trace (Gantt timeline), Diagnose (root-cause), Lineage (artifact graph), Eval (suite results & baselines) |
 | **Comparison** | Diff (side-by-side with filter bar, compare with previous run), Bisect (NodeMap, DAG visualization, divergence metrics) |
 | **Costs** | Cost Dashboard (charts), Budget Management |
 | **System** | Doctor (health), Plugins, Gateway, Export, Scheduler (cron) |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,5 +1,8 @@
 # Binex vs. LangGraph, CrewAI & AutoGen
 
+> Looking for observability and orchestration tools instead? See
+> [Binex vs. LangSmith, Langfuse, n8n & Langflow](comparisons.md).
+
 "Why Binex over LangGraph / CrewAI / AutoGen?" — the honest answer is that they
 solve *different* problems. The other three are frameworks for **building** agent
 systems. Binex is a **debuggable runtime** for them: its whole reason for

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,5 +1,8 @@
 # Comparisons
 
+> Comparing against agent *frameworks*? See
+> [Binex vs. LangGraph, CrewAI & AutoGen](comparison.md).
+
 Binex occupies a specific niche: a **local-first, debuggable runtime** for AI agent pipelines. This page compares it honestly to four tools that appear in the same conversation — LangSmith, Langfuse, n8n, and Langflow. The goal is to help you decide which tool fits your situation, not to sell you on Binex.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,11 @@ Binex orchestrates multi-agent workflows defined in YAML. It executes DAG-based 
 - **OpenTelemetry tracing** — Optional run-level and node-level spans for external collectors (Jaeger, Tempo), with zero overhead when disabled.
 - **Workflow versioning** — Schema versioning with migration framework, plus workflow snapshots stored in SQLite for run reproducibility.
 - **Export & webhooks** — Export run data to CSV/JSON, webhook notifications on run lifecycle events.
+- **Eval & regression testing** — YAML eval suites with blessed baselines (`binex eval run|bless|baselines`) plus per-node assertions and golden-run gating (`binex eval golden`) for CI.
+- **MCP server** — Expose runs, debugging, and evals to Claude Code, Cursor, or any MCP-compatible agent via `binex mcp serve`.
+- **OTel trace import** — Turn OTLP/JSON traces from any agent framework into Binex runs (`binex import otel`, live `binex collect` collector).
+- **Cron scheduler** — Register workflows with a `schedule:` field and run them on cron via `binex scheduler`.
+- **Web UI** — Visual drag-and-drop editor, live run view (SSE), debugging, diffing, cost dashboards — 20 pages of full CLI parity (`binex ui`).
 - **Interactive CLI** — Project scaffolding, workflow validation, a built-in doctor command, and a start wizard to get you productive quickly.
 
 ## Install
@@ -44,7 +49,7 @@ See the [Quickstart](quickstart.md) for a full walkthrough.
 | Section | Description |
 |---------|-------------|
 | [Quickstart](quickstart.md) | Install Binex and run your first workflow in under 5 minutes |
-| [CLI Reference](cli/run.md) | All commands: `hello`, `init`, `run`, `debug`, `trace`, `replay`, `diff`, `artifacts`, `dev`, `doctor`, `validate`, `scaffold`, `cancel`, `start`, `explore`, `diagnose`, `bisect`, `gateway`, `plugins`, `export`, `workflow` |
+| [CLI Reference](cli/run.md) | All commands: `hello`, `init`, `run`, `resume`, `debug`, `trace`, `replay`, `diff`, `artifacts`, `dev`, `doctor`, `validate`, `scaffold`, `cancel`, `start`, `explore`, `diagnose`, `bisect`, `gateway`, `plugins`, `export`, `workflow`, `eval`, `import`, `collect`, `mcp`, `scheduler`, `ui`, `cost` |
 | [Concepts](concepts/agents.md) | Core concepts: agents, workflows, artifacts, execution model, lineage tracking |
 | [Architecture](architecture/overview.md) | Runtime internals: orchestrator, stores, adapters, scheduler, DAG engine |
 | [Workflow Format](workflows/format.md) | YAML schema reference with node specs, variables, conditionals, and defaults |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
   - Home: index.md
   - Demo: demo.md
   - Quickstart: quickstart.md
-  - Comparison: comparison.md
+  - vs LangGraph / CrewAI / AutoGen: comparison.md
   - Guides:
     - Debugging & Observability: guides/debugging.md
   - Concepts:
@@ -95,7 +95,7 @@ nav:
     - Import from OTel: import.md
     - Tools & MCP: features/tools-mcp.md
     - CAO Adapter: features/cao-adapter.md
-    - Comparisons: comparisons.md
+    - vs LangSmith / Langfuse / n8n: comparisons.md
   - Workflows:
     - Format: workflows/format.md
     - Examples: workflows/examples.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "ruff",
     "mypy",
     "mkdocs-material",
+    "mkdocs-glightbox",
     "pytest-playwright",
     "pytest-xdist",
     "respx",


### PR DESCRIPTION
## What

Phase-5 documentation pass; every claim below was fact-checked against the code before touching it:

- **README**: "19 Pages" → **20** (counted `ui/src/pages/*.tsx` minus non-pages; EvalPage landed with #121), Eval added to the pages table.
- **docs/index.md**: Key Features was missing five shipped capabilities — eval & regression testing, MCP server, OTel import/collector, cron scheduler, and (surprisingly) the Web UI itself. CLI list in the docs table completed with `resume`/`eval`/`import`/`collect`/`mcp`/`scheduler`/`ui`/`cost`.
- **comparison.md vs comparisons.md**: two legitimate but differently-scoped docs (vs agent frameworks / vs observability tools) had indistinguishable nav titles — renamed to "vs LangGraph / CrewAI / AutoGen" and "vs LangSmith / Langfuse / n8n", cross-linked at the top of each.
- **pyproject.toml**: `mkdocs-glightbox` is required by `mkdocs.yml` and installed ad-hoc in `docs.yml`, but was never declared — the recurring "installed ≠ declared" bug class.

Archival `docs/plans/*.md` deliberately untouched.

## Verification

```
mkdocs build --strict → Documentation built in 8.49 seconds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)